### PR TITLE
Opencl eliminate globals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,8 @@ include(cmake/ConfigGen.cmake)
 
 # ---[ Options
 caffe_option(CPU_ONLY   "Build Caffe without CUDA support" OFF) # TODO: rename to USE_CUDA
-caffe_option(USE_OPENCL "Build Caffe with OpenCL support" OFF)
-caffe_option(USE_CUDNN "Build Caffe with cuDNN libary support" ON IF NOT CPU_ONLY OR USE_OPENCL)
+caffe_option(USE_OPENCL "Build Caffe with OpenCL support" ON)
+caffe_option(USE_CUDNN "Build Caffe with cuDNN libary support" OFF) # IF NOT CPU_ONLY OR USE_OPENCL)
 caffe_option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 caffe_option(BUILD_python "Build Python wrapper" ON)
 set(python_version "2" CACHE STRING "Specify which python version to use")

--- a/cmake/Modules/FindOpenCL.cmake
+++ b/cmake/Modules/FindOpenCL.cmake
@@ -74,7 +74,8 @@ if( LIB64 )
         DOC "OpenCL dynamic library path"
         PATH_SUFFIXES x86_64 x64 x86_64/sdk
         PATHS
-            /usr/lib /usr/lib/x86_64-linux-gnu
+            /usr/lib
+            #/usr/lib/x86_64-linux-gnu
     )
 else( )
     find_library( OPENCL_LIBRARIES
@@ -86,7 +87,8 @@ else( )
         DOC "OpenCL dynamic library path"
         PATH_SUFFIXES x86 x86/sdk Win32
         PATHS
-            /usr/lib /usr/lib/i386-linux-gnu
+            /usr/lib
+            #/usr/lib/i386-linux-gnu
     )
 endif( )
 mark_as_advanced( OPENCL_LIBRARIES )

--- a/cmake/Modules/FindclBLAS.cmake
+++ b/cmake/Modules/FindclBLAS.cmake
@@ -3,6 +3,7 @@
 SET(clBLAS_INCLUDE_SEARCH_PATHS
   /usr/include
   /usr/local/include
+  /opt/clBLAS/include
   $ENV{clBLAS_HOME}/include
 )
 
@@ -13,6 +14,7 @@ SET(clBLAS_LIB_SEARCH_PATHS
         /usr/lib64
         /usr/local/lib
         /usr/local/lib64
+        /opt/clBLAS/lib64
         $ENV{clBLAS_HOME}
         $ENV{clBLAS_HOME}/lib
         $ENV{clBLAS_HOME}/lib64

--- a/examples/mnist/train_lenet.sh
+++ b/examples/mnist/train_lenet.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-./build/tools/caffe train --solver=examples/mnist/lenet_solver.prototxt
+../caffe_build/tools/caffe train --solver=examples/mnist/lenet_solver.prototxt

--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -112,6 +112,9 @@ class Caffe {
 //  static bool GPU_USE_CUDA;
 //  static bool GPU_USE_OPENCL;
 
+  // Used for benchmarking.
+  static void DeviceSync();
+
   // This random number generator facade hides boost and CUDA rng
   // implementation from one another (for cross-platform compatibility).
   class RNG {

--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -109,8 +109,8 @@ class Caffe {
     return *singleton_;
   }
   enum Brew { CPU, GPU };
-  static bool GPU_USE_CUDA;
-  static bool GPU_USE_OPENCL;
+//  static bool GPU_USE_CUDA;
+//  static bool GPU_USE_OPENCL;
 
   // This random number generator facade hides boost and CUDA rng
   // implementation from one another (for cross-platform compatibility).

--- a/include/caffe/util/OpenCL/OpenCLDevice.hpp
+++ b/include/caffe/util/OpenCL/OpenCLDevice.hpp
@@ -67,7 +67,7 @@ private:
 	cl_context context;
 	std::vector<cl_program> programs;
 	cl_command_queue queue;
-	std::map<std::string, cl_kernel> kernel;
+  std::map<std::string, cl_kernel> kernel_map_;
 
 	std::map<const void*, caffe::OpenCLMemory> memory;
 };

--- a/include/caffe/util/OpenCL/OpenCLDevice.hpp
+++ b/include/caffe/util/OpenCL/OpenCLDevice.hpp
@@ -2,6 +2,7 @@
 #define __OPENCL_DEVICE_HPP__
 
 #include <CL/cl.h>
+#include <CL/cl.hpp>
 #include <string>
 #include <iostream>
 #include <map>
@@ -14,19 +15,20 @@ class OpenCLDevice {
 
 public:
 	OpenCLDevice();
-	OpenCLDevice(cl_platform_id pid, cl_device_id did);
+  OpenCLDevice(cl_platform_id pid, cl_device_id did);
 	OpenCLDevice(const OpenCLDevice& dev);
 	~OpenCLDevice();
 
 	bool query();
 	void print();
+  void SetContext(cl::Context context);
 	cl_device_type type();
 	std::string name();
 	cl_device_id id();
-	bool createContext();
+  //bool createContext();
 	bool compile(std::string source);
 	bool createQueue();
-	cl_context* getContext();
+  cl_context getContext();
 	cl_command_queue* getQueue();
 	cl_kernel* getKernel(std::string name);
 	bool add(OpenCLMemory& clMem);
@@ -37,7 +39,6 @@ public:
 	std::string getDeviceName();
 	cl_uint getDeviceMemBaseAddrAlign();
 	size_t getMemoryUsage();
-
 protected:
 
 private:
@@ -64,7 +65,7 @@ private:
 	cl_bool deviceHostUnifiedMem;
 	cl_uint deviceMemBaseAddrAlign;
 	std::string deviceName;
-	cl_context context;
+  cl::Context context_;
 	std::vector<cl_program> programs;
 	cl_command_queue queue;
   std::map<std::string, cl_kernel> kernel_map_;

--- a/include/caffe/util/OpenCL/OpenCLDevice.hpp
+++ b/include/caffe/util/OpenCL/OpenCLDevice.hpp
@@ -39,6 +39,7 @@ public:
 	std::string getDeviceName();
 	cl_uint getDeviceMemBaseAddrAlign();
 	size_t getMemoryUsage();
+  void Synchronize();
 protected:
 
 private:

--- a/include/caffe/util/OpenCL/OpenCLManager.hpp
+++ b/include/caffe/util/OpenCL/OpenCLManager.hpp
@@ -21,7 +21,6 @@ class OpenCLManager {
   OpenCLManager();
   ~OpenCLManager();
   OpenCLPlatform* getPlatform(unsigned int idx);
-  bool LazyQuery();
   bool Query();
   //cl::Platform current_platform_; // cl_platform_id* 					platformPtr;
   int current_platform_index_;

--- a/include/caffe/util/OpenCL/OpenCLManager.hpp
+++ b/include/caffe/util/OpenCL/OpenCLManager.hpp
@@ -27,6 +27,8 @@ class OpenCLManager {
   int current_platform_index_;
   Platforms platforms_;
   int device_id_;
+  bool initialized_;
+  // singleton instance.
   static OpenCLManager instance_;
 };
 

--- a/include/caffe/util/OpenCL/OpenCLManager.hpp
+++ b/include/caffe/util/OpenCL/OpenCLManager.hpp
@@ -1,30 +1,33 @@
 #ifndef __OPENCL_MANAGER_HPP__
 #define __OPENCL_MANAGER_HPP__
 
-#include <CL/cl.h>
+#include <CL/cl.hpp>
 #include <vector>
 #include <caffe/util/OpenCL/OpenCLPlatform.hpp>
 
 namespace caffe {
 
+typedef std::vector<caffe::OpenCLPlatform> Platforms;
+typedef Platforms::iterator PlatformIter;
 class OpenCLManager {
-
-public:
-	OpenCLManager();
-	~OpenCLManager();
-
-	bool query();
-	void print();
-	int getNumPlatforms();
-	OpenCLPlatform* getPlatform(unsigned int idx);
-
-protected:
-
-private:
-
-	unsigned int						numOpenCLPlatforms;
-	cl_platform_id* 					platformPtr;
-	std::vector<caffe::OpenCLPlatform> 	platforms;
+ public:
+  static bool Init();
+  static void Print();
+  static int GetNumPlatforms();
+  static OpenCLPlatform& CurrentPlatform();
+  static void SetDeviceId(int device_id);
+ private:
+  void Check();
+  OpenCLManager();
+  ~OpenCLManager();
+  OpenCLPlatform* getPlatform(unsigned int idx);
+  bool LazyQuery();
+  bool Query();
+  //cl::Platform current_platform_; // cl_platform_id* 					platformPtr;
+  int current_platform_index_;
+  Platforms platforms_;
+  int device_id_;
+  static OpenCLManager instance_;
 };
 
 }

--- a/include/caffe/util/OpenCL/OpenCLPlatform.hpp
+++ b/include/caffe/util/OpenCL/OpenCLPlatform.hpp
@@ -1,45 +1,44 @@
 #ifndef __OPENCL_PLATFORM_HPP__
 #define __OPENCL_PLATFORM_HPP__
 
-#include <CL/cl.h>
+#include <CL/cl.hpp>
 #include <vector>
 #include <caffe/util/OpenCL/OpenCLDevice.hpp>
 
 namespace caffe {
 
 class OpenCLPlatform {
-
 public:
 	OpenCLPlatform();
 	OpenCLPlatform(const OpenCLPlatform& pf);
-	OpenCLPlatform(cl_platform_id id);
+  OpenCLPlatform(cl::Platform platform);
 
 	~OpenCLPlatform();
 
-	bool query();
+  bool Query();
 	void print();
 	int  getNumCPUDevices();
 	int  getNumGPUDevices();
-	char* name();
-	char* vendor();
-	char* version();
-	char* profile();
+  std::string name();
+  std::string vendor();
+  std::string version();
+  std::string profile();
+  void SetCurrentDevice(int device_index);
+  OpenCLDevice& CurrentDevice();
 	OpenCLDevice* getDevice(cl_device_type type, unsigned int idx);
 	cl_platform_id id();
 	bool createContext();
 	bool compile(std::string sources);
 	int getNumDevices(cl_device_type type);
-
-protected:
-
 private:
-
-	cl_platform_id platformID;
-	char* platformName;
-	char* platformVendor;
-	char* platformVersion;
-	char* platformExtensions;
-	char* platformProfile;
+  void Check();
+  //cl_platform_id platformID;
+  cl::Platform platform_;
+  std::string name_;
+  std::string vendor_;
+  std::string version_;
+  std::string extensions_;
+  std::string profile_;
 	cl_uint numCPUDevices;
 	cl_uint numGPUDevices;
 	cl_uint numDevices;
@@ -49,6 +48,7 @@ private:
 	std::vector<caffe::OpenCLDevice>	devices;
 	cl_context context;
 	std::vector<cl_program> programs;
+  int current_device_index_;
 };
 
 } // namespace caffe

--- a/include/caffe/util/OpenCL/OpenCLPlatform.hpp
+++ b/include/caffe/util/OpenCL/OpenCLPlatform.hpp
@@ -46,8 +46,9 @@ private:
 	cl_device_id*	cpuDevicePtr;
 	cl_device_id*	gpuDevicePtr;
 	std::vector<caffe::OpenCLDevice>	devices;
-	cl_context context;
-	std::vector<cl_program> programs;
+//  cl_context context;
+  cl::Context context_;
+//	std::vector<cl_program> programs;
   int current_device_index_;
 };
 

--- a/include/caffe/util/OpenCL/OpenCLPlatform.hpp
+++ b/include/caffe/util/OpenCL/OpenCLPlatform.hpp
@@ -30,6 +30,7 @@ public:
 	bool createContext();
 	bool compile(std::string sources);
 	int getNumDevices(cl_device_type type);
+  void DeviceSynchronize();
 private:
   void Check();
   //cl_platform_id platformID;

--- a/include/caffe/util/OpenCL/OpenCLSupport.hpp
+++ b/include/caffe/util/OpenCL/OpenCLSupport.hpp
@@ -92,11 +92,11 @@
 	std::vector<cl_mem> sb;\
 	std::map<const void*, std::pair<void*, size_t> > bm;
 
-#define CL_SET_TYPE_KERNEL_ARG(type, variable) \
-	if ( ! clSetKernelTypeArg(variable, idx) ) return false;
+#define CL_SET_TYPE_KERNEL_ARG(type, variable, kernel) \
+  if ( ! clSetKernelTypeArg(variable, idx, kernel) ) return false;
 
-#define CL_SET_ARRAY_KERNEL_ARG(variable) \
-	if ( ! clSetKernelArrayArg(*variable, idx, sb, bm) ) return false;
+#define CL_SET_ARRAY_KERNEL_ARG(variable, kernel) \
+  if ( ! clSetKernelArrayArg(*variable, idx, sb, bm, kernel) ) return false;
 
 #define CL_SET_KERNEL_ARG_END\
 	clReleaseSubBuffers(sb);\
@@ -111,7 +111,7 @@ namespace OpenCL {
 	int64_t getTickCount();
 	double getTickFrequency();
 
-	bool init();
+//	bool init();
 
 	bool clMalloc(void** virtualPtr, size_t);
 	bool clFree(void* virtualPtr);
@@ -121,8 +121,9 @@ namespace OpenCL {
 	bool clIsVirtualMemory(const void* p);
 	bool clMakeLogical(const void* ptr_virtual, const void** ptr_logical);
 	bool clMakeLogical2(const void* ptr_virtual, const void** ptr_logical, std::vector<cl_mem>& subBuffers, std::map<const void*, std::pair<void*, size_t> >& bufferMap);
-	template<typename T> bool clSetKernelTypeArg(T variable, unsigned int& idx);
-	bool clSetKernelArrayArg(const void* ptr_virtual, unsigned int& idx, std::vector<cl_mem>& subBuffers, std::map<const void*, std::pair<void*, size_t> >& bufferMap);
+  template<typename T> bool clSetKernelTypeArg(T variable, unsigned int& idx,
+                                               cl_kernel* kernel);
+  bool clSetKernelArrayArg(const void* ptr_virtual, unsigned int& idx, std::vector<cl_mem>& subBuffers, std::map<const void*, std::pair<void*, size_t> >& bufferMap, cl_kernel* kernel);
 	bool clReleaseSubBuffers(std::vector<cl_mem>& subBuffers);
 	bool clReleaseBufferMap(std::map<const void*, std::pair<void*, size_t> >& bufferMap);
 
@@ -167,12 +168,12 @@ namespace OpenCL {
 	const static int COPY_DEFAULT    = 4;
 
 	extern bool inititialized;
-	extern caffe::OpenCLManager mgr;
-	extern caffe::OpenCLPlatform* pf;
-	extern caffe::OpenCLDevice* gpu;
-	extern cl_context*	context;
-	extern cl_command_queue* queue;
-	extern cl_kernel* kernel;
+//	extern caffe::OpenCLManager mgr;
+//	extern caffe::OpenCLPlatform* pf;
+//	extern caffe::OpenCLDevice* gpu;
+//	extern cl_context*	context;
+//	extern cl_command_queue* queue;
+//	extern cl_kernel* kernel;
 
 } // namespace OpenCL
 

--- a/include/caffe/util/OpenCL/OpenCLSupport.hpp
+++ b/include/caffe/util/OpenCL/OpenCLSupport.hpp
@@ -167,7 +167,7 @@ namespace OpenCL {
 	const static int COPY_GPU_TO_GPU = 3;
 	const static int COPY_DEFAULT    = 4;
 
-	extern bool inititialized;
+//	extern bool inititialized;
 //	extern caffe::OpenCLManager mgr;
 //	extern caffe::OpenCLPlatform* pf;
 //	extern caffe::OpenCLDevice* gpu;

--- a/include/caffe/util/benchmark.hpp
+++ b/include/caffe/util/benchmark.hpp
@@ -111,8 +111,6 @@ LOG(INFO) << "TIME("<<name<<") = "<<((float) floor(1000*(1000*(end-bgn))))/1000<
 #endif // CPU_ONLY
 
 
-#if defined(USE_CUDA)
-
 #define	BENCH(result, this)\
 {\
 	struct timeval s;\
@@ -121,7 +119,7 @@ LOG(INFO) << "TIME("<<name<<") = "<<((float) floor(1000*(1000*(end-bgn))))/1000<
 		bgn = s.tv_sec * 1.0 + s.tv_usec * 1.e-6;\
 	}\
 	(this); \
-	cudaDeviceSynchronize();\
+  caffe::Caffe::DeviceSync(); \
 	double end = 0.0;\
 	if (gettimeofday(&s, 0) == 0) {\
 		end = s.tv_sec * 1.0 + s.tv_usec * 1.e-6;\
@@ -132,31 +130,6 @@ LOG(INFO) << "TIME("<<name<<") = "<<((float) floor(1000*(1000*(end-bgn))))/1000<
 	LOG(INFO) << "TIME::CUDA::"<<result.function.c_str()<<" = "<<result.time<<"ms";\
 	caffe::Timer::log("bench.csv", result);\
 }
-
-#endif // USE_CUDA
-
-#if defined(USE_OPENCL)
-
-#define	BENCH(result, this)\
-{\
-	struct timeval s;\
-	double bgn = 0.0;\
-	if (gettimeofday(&s, 0) == 0) {\
-		bgn = s.tv_sec * 1.0 + s.tv_usec * 1.e-6;\
-	}\
-	(this); \
-	double end = 0.0;\
-	if (gettimeofday(&s, 0) == 0) {\
-		end = s.tv_sec * 1.0 + s.tv_usec * 1.e-6;\
-	}\
-	result.time 	= ((float) floor(1000*(1000*(end-bgn))))/1000;\
-	result.function = __func__;\
-	result.file     = __FILE__;\
-	LOG(INFO) << "TIME::OpenCL::"<<result.function.c_str()<<" = "<<result.time<<"ms";\
-	caffe::Timer::log("bench.csv", result);\
-}
-
-#endif // USE_OPENCL
 
 #define SNAP_LENGTH 36
 #define snap(array, length) \

--- a/src/caffe/common.cpp
+++ b/src/caffe/common.cpp
@@ -7,8 +7,8 @@
 
 namespace caffe {
 
-bool caffe::Caffe::GPU_USE_CUDA 	= false;
-bool caffe::Caffe::GPU_USE_OPENCL = false;
+//bool caffe::Caffe::GPU_USE_CUDA 	= false;
+//bool caffe::Caffe::GPU_USE_OPENCL = false;
 
 shared_ptr<Caffe> Caffe::singleton_;
 
@@ -46,8 +46,6 @@ void GlobalInit(int* pargc, char*** pargv) {
 
 Caffe::Caffe()
     : random_generator_(), mode_(Caffe::CPU) {
-	GPU_USE_CUDA   = false;
-	GPU_USE_OPENCL = false;
 }
 
 Caffe::~Caffe() { }
@@ -282,9 +280,9 @@ const char* curandGetErrorString(curandStatus_t error) {
 #ifdef USE_OPENCL // OpenCL Support
 
 Caffe::Caffe() : random_generator_(), mode_(Caffe::CPU) {
-	caffe::OpenCL::init();
-	GPU_USE_CUDA   = false;
-	GPU_USE_OPENCL = true;
+  caffe::OpenCLManager::Init();
+//	GPU_USE_CUDA   = false;
+//	GPU_USE_OPENCL = true;
 }
 
 Caffe::~Caffe() {
@@ -296,9 +294,11 @@ void Caffe::set_random_seed(const unsigned int seed) {
 }
 
 void Caffe::SetDevice(const int device_id) {
+  OpenCLManager::SetDeviceId(device_id);
 }
 
 void Caffe::DeviceQuery() {
+  OpenCLManager::CurrentPlatform().CurrentDevice().print();
 }
 
 class Caffe::RNG::Generator {

--- a/src/caffe/common.cpp
+++ b/src/caffe/common.cpp
@@ -4,6 +4,7 @@
 
 #include "caffe/common.hpp"
 #include "caffe/util/rng.hpp"
+#include "caffe/util/OpenCL/OpenCLManager.hpp"
 
 namespace caffe {
 
@@ -11,6 +12,15 @@ namespace caffe {
 //bool caffe::Caffe::GPU_USE_OPENCL = false;
 
 shared_ptr<Caffe> Caffe::singleton_;
+
+void Caffe::DeviceSync() {
+#ifdef USE_CUDA
+  cudaDeviceSynchronize();
+#endif
+#ifdef USE_OPENCL
+  OpenCLManager::CurrentPlatform().DeviceSynchronize();
+#endif
+}
 
 // random seeding
 int64_t cluster_seedgen(void) {

--- a/src/caffe/layers/bnll_layer.cpp
+++ b/src/caffe/layers/bnll_layer.cpp
@@ -49,35 +49,38 @@ namespace OpenCL {
 
 template<typename T>
 bool clBNLLLayerForward(const int count, const T* bottom_data, T* top_data) {
-
+  OpenCLDevice& current_device = OpenCLManager::CurrentPlatform().CurrentDevice();
 	std::string kernel_name = clGetKernelName<T>("BNLLForward");
-
-	queue = gpu->getQueue();
+  cl_command_queue* queue = current_device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << current_device.name()
+               << "> failed to get OpenCL command queue";
 		return false;
 	}
 
-	kernel = gpu->getKernel(kernel_name);
+  cl_kernel* kernel = current_device.getKernel(kernel_name);
 	if ( kernel == NULL ) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, count)
-	CL_SET_ARRAY_KERNEL_ARG(&bottom_data)
-	CL_SET_ARRAY_KERNEL_ARG(&top_data)
+  CL_SET_TYPE_KERNEL_ARG(int, count, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&bottom_data, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&top_data, kernel)
 
 	size_t global = CAFFE_GET_GLOBAL_WORKITEMS(count, OPENCL_LOCAL_SIZE);
 	size_t local  = CAFFE_GET_LOCAL_WORKITEMS(count, OPENCL_LOCAL_SIZE);
 
 	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+    LOG(ERROR) << "Failed to enqueue kernel '"
+               << kernel_name.c_str() << "' on GPU "
+               << current_device.name()<<" : "<<caffe::OpenCL::what(err);
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '"<<kernel_name.c_str()
+             << "' executed on GPU " << current_device.name();
 
 	CL_SET_KERNEL_ARG_END
 
@@ -88,36 +91,40 @@ template bool clBNLLLayerForward<double>(const int count, const double* bottom_d
 
 template<typename T>
 bool clBNLLLayerBackward(const int count, const T* top_diff, const T* bottom_data, T* bottom_diff) {
-
+  OpenCLDevice& current_device = OpenCLManager::CurrentPlatform().CurrentDevice();
 	std::string kernel_name = clGetKernelName<T>("BNLLBackward");
-
-	queue = gpu->getQueue();
-	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+  cl_command_queue* queue = current_device.getQueue();
+  if (!queue) {
+    LOG(ERROR) << current_device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
-	kernel = gpu->getKernel(kernel_name);
+  cl_kernel* kernel = current_device.getKernel(kernel_name);
 	if ( kernel == NULL ) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, count)
-	CL_SET_ARRAY_KERNEL_ARG(&top_diff)
-	CL_SET_ARRAY_KERNEL_ARG(&bottom_data)
-	CL_SET_ARRAY_KERNEL_ARG(&bottom_diff)
+  CL_SET_TYPE_KERNEL_ARG(int, count, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&top_diff, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&bottom_data, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&bottom_diff, kernel)
 
 	size_t global = CAFFE_GET_GLOBAL_WORKITEMS(count, OPENCL_LOCAL_SIZE);
 	size_t local  = CAFFE_GET_LOCAL_WORKITEMS(count, OPENCL_LOCAL_SIZE);
 
-	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
+  err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL,
+                               &global, &local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+    LOG(ERROR) << "Failed to enqueue kernel '"
+               << kernel_name.c_str()
+               << "' on GPU "<< current_device.name()<<" : "
+               << caffe::OpenCL::what(err);
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '" << kernel_name
+             <<"' executed on GPU " << current_device.name();
 
 	CL_SET_KERNEL_ARG_END
 

--- a/src/caffe/layers/dropout_layer.cpp
+++ b/src/caffe/layers/dropout_layer.cpp
@@ -78,38 +78,39 @@ namespace OpenCL {
 
 template<typename T>
 bool clDropoutLayerForward(const int count, const T* bottom_data, const unsigned int* mask, const unsigned int threshold, const T scale, T* top_data) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
 	std::string kernel_name = clGetKernelName<T>("DropoutForward");
 
-	queue = gpu->getQueue();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
-	kernel = gpu->getKernel(kernel_name);
+  cl_kernel* kernel = device.getKernel(kernel_name);
 	if ( kernel == NULL ) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, count)
-	CL_SET_ARRAY_KERNEL_ARG(&bottom_data)
-	CL_SET_ARRAY_KERNEL_ARG(&mask)
-	CL_SET_TYPE_KERNEL_ARG(const unsigned int, threshold)
-	CL_SET_TYPE_KERNEL_ARG(T, scale)
-	CL_SET_ARRAY_KERNEL_ARG(&top_data)
+  CL_SET_TYPE_KERNEL_ARG(int, count, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&bottom_data, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&mask, kernel)
+  CL_SET_TYPE_KERNEL_ARG(const unsigned int, threshold, kernel)
+  CL_SET_TYPE_KERNEL_ARG(T, scale, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&top_data, kernel)
 
 	size_t global = count;//CAFFE_GET_GLOBAL_WORKITEMS(count, OPENCL_LOCAL_SIZE);
 	size_t local  = 1;//CAFFE_GET_LOCAL_WORKITEMS(count, OPENCL_LOCAL_SIZE);
 
 	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+    LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<device.name()<<" : "<<caffe::OpenCL::what(err);
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<device.name();
 
 	CL_SET_KERNEL_ARG_END
 
@@ -120,38 +121,39 @@ template bool clDropoutLayerForward<double>(const int count, const double* botto
 
 template<typename T>
 bool clDropoutLayerBackward(const int count, const T* top_diff, const unsigned int* mask, const unsigned int threshold, const T scale, T* bottom_diff) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
 	std::string kernel_name = clGetKernelName<T>("DropoutBackward");
 
-	queue = gpu->getQueue();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
-	kernel = gpu->getKernel(kernel_name);
+  cl_kernel* kernel = device.getKernel(kernel_name);
 	if ( kernel == NULL ) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, count)
-	CL_SET_ARRAY_KERNEL_ARG(&top_diff)
-	CL_SET_ARRAY_KERNEL_ARG(&mask)
-	CL_SET_TYPE_KERNEL_ARG(unsigned int, threshold)
-	CL_SET_TYPE_KERNEL_ARG(T, scale)
-	CL_SET_ARRAY_KERNEL_ARG(&bottom_diff)
+  CL_SET_TYPE_KERNEL_ARG(int, count, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&top_diff, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&mask, kernel)
+  CL_SET_TYPE_KERNEL_ARG(unsigned int, threshold, kernel)
+  CL_SET_TYPE_KERNEL_ARG(T, scale, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&bottom_diff, kernel)
 
 	size_t global = count;//CAFFE_GET_GLOBAL_WORKITEMS(count, OPENCL_LOCAL_SIZE);
 	size_t local  = 1;//CAFFE_GET_LOCAL_WORKITEMS(count, OPENCL_LOCAL_SIZE);
 
 	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+    LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<device.name()<<" : "<<caffe::OpenCL::what(err);
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<device.name();
 
 	CL_SET_KERNEL_ARG_END
 

--- a/src/caffe/layers/eltwise_layer.cpp
+++ b/src/caffe/layers/eltwise_layer.cpp
@@ -162,38 +162,39 @@ namespace OpenCL {
 
 template<typename T>
 bool clMaxForward(const int nthreads, const T* bottom_data_a, const T* bottom_data_b, const int blob_idx, T* top_data, int* mask) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
 	std::string kernel_name = clGetKernelName<T>("MaxForward");
 
-	queue = gpu->getQueue();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
-	kernel = gpu->getKernel(kernel_name);
+  cl_kernel* kernel = device.getKernel(kernel_name);
 	if ( kernel == NULL ) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, nthreads)
-	CL_SET_ARRAY_KERNEL_ARG(&bottom_data_a)
-	CL_SET_ARRAY_KERNEL_ARG(&bottom_data_b)
-	CL_SET_TYPE_KERNEL_ARG(int, blob_idx)
-	CL_SET_ARRAY_KERNEL_ARG(&top_data)
-	CL_SET_ARRAY_KERNEL_ARG(&mask)
+  CL_SET_TYPE_KERNEL_ARG(int, nthreads, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&bottom_data_a, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&bottom_data_b, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, blob_idx, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&top_data, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&mask, kernel)
 
 	size_t global = CAFFE_GET_GLOBAL_WORKITEMS(nthreads, OPENCL_LOCAL_SIZE);
 	size_t local  = CAFFE_GET_LOCAL_WORKITEMS(nthreads, OPENCL_LOCAL_SIZE);
 
 	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+    LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<device.name()<<" : "<<caffe::OpenCL::what(err);
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<device.name();
 
 	CL_SET_KERNEL_ARG_END
 
@@ -204,37 +205,38 @@ template bool clMaxForward<double>(const int nthreads, const double* bottom_data
 
 template<typename T>
 bool clMaxBackward(const int nthreads, const T* top_diff, const int blob_idx, const int* mask, T* bottom_diff) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
 	std::string kernel_name = clGetKernelName<T>("MaxBackward");
 
-	queue = gpu->getQueue();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
-	kernel = gpu->getKernel(kernel_name);
+  cl_kernel* kernel = device.getKernel(kernel_name);
 	if ( kernel == NULL ) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, nthreads)
-	CL_SET_ARRAY_KERNEL_ARG(&top_diff)
-	CL_SET_TYPE_KERNEL_ARG(int, blob_idx)
-	CL_SET_ARRAY_KERNEL_ARG(&mask)
-	CL_SET_ARRAY_KERNEL_ARG(&bottom_diff)
+  CL_SET_TYPE_KERNEL_ARG(int, nthreads, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&top_diff, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, blob_idx, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&mask, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&bottom_diff, kernel)
 
 	size_t global = CAFFE_GET_GLOBAL_WORKITEMS(nthreads, OPENCL_LOCAL_SIZE);
 	size_t local  = CAFFE_GET_LOCAL_WORKITEMS(nthreads, OPENCL_LOCAL_SIZE);
 
 	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+    LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<< device.name()<<" : "<<caffe::OpenCL::what(err);
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<device.name();
 
 	CL_SET_KERNEL_ARG_END
 

--- a/src/caffe/layers/pooling_layer.cpp
+++ b/src/caffe/layers/pooling_layer.cpp
@@ -338,49 +338,50 @@ bool clMaxPoolBackward(
 		const int pad_h,
 		const int pad_w,
 		T* bottom_diff) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
 	std::string kernel_name = clGetKernelName<T>("MaxPoolBackward");
 
-	queue = gpu->getQueue();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
-	kernel = gpu->getKernel(kernel_name);
+  cl_kernel* kernel = device.getKernel(kernel_name);
 	if ( kernel == NULL ) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, nthreads)
-	CL_SET_ARRAY_KERNEL_ARG(&top_diff)
-	CL_SET_ARRAY_KERNEL_ARG(&mask)
-	CL_SET_ARRAY_KERNEL_ARG(&top_mask)
-	CL_SET_TYPE_KERNEL_ARG(int, num)
-	CL_SET_TYPE_KERNEL_ARG(int, channels)
-	CL_SET_TYPE_KERNEL_ARG(int, height)
-	CL_SET_TYPE_KERNEL_ARG(int, width)
-	CL_SET_TYPE_KERNEL_ARG(int, pooled_height)
-	CL_SET_TYPE_KERNEL_ARG(int, pooled_width)
-	CL_SET_TYPE_KERNEL_ARG(int, kernel_h)
-	CL_SET_TYPE_KERNEL_ARG(int, kernel_w)
-	CL_SET_TYPE_KERNEL_ARG(int, stride_h)
-	CL_SET_TYPE_KERNEL_ARG(int, stride_w)
-	CL_SET_TYPE_KERNEL_ARG(int, pad_h)
-	CL_SET_TYPE_KERNEL_ARG(int, pad_w)
-	CL_SET_ARRAY_KERNEL_ARG(&bottom_diff)
+  CL_SET_TYPE_KERNEL_ARG(int, nthreads, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&top_diff, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&mask, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&top_mask, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, num, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, channels, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, height, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, width, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, pooled_height, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, pooled_width, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, kernel_h, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, kernel_w, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, stride_h, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, stride_w, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, pad_h, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, pad_w, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&bottom_diff, kernel)
 
 	size_t global = nthreads;//CAFFE_GET_GLOBAL_WORKITEMS(nthreads, OPENCL_LOCAL_SIZE);
 	size_t local  = 1;//CAFFE_GET_LOCAL_WORKITEMS(nthreads, OPENCL_LOCAL_SIZE);
 
 	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+    LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<device.name()<<" : "<<caffe::OpenCL::what(err);
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<device.name();
 
 	CL_SET_KERNEL_ARG_END
 
@@ -406,47 +407,48 @@ bool clAvePoolBackward(
 		const int pad_h,
 		const int pad_w,
 		T* bottom_diff) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
 	std::string kernel_name = clGetKernelName<T>("AvePoolBackward");
 
-	queue = gpu->getQueue();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
-	kernel = gpu->getKernel(kernel_name);
+  cl_kernel* kernel = device.getKernel(kernel_name);
 	if ( kernel == NULL ) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, nthreads)
-	CL_SET_ARRAY_KERNEL_ARG(&top_diff)
-	CL_SET_TYPE_KERNEL_ARG(int, num)
-	CL_SET_TYPE_KERNEL_ARG(int, channels)
-	CL_SET_TYPE_KERNEL_ARG(int, height)
-	CL_SET_TYPE_KERNEL_ARG(int, width)
-	CL_SET_TYPE_KERNEL_ARG(int, pooled_height)
-	CL_SET_TYPE_KERNEL_ARG(int, pooled_width)
-	CL_SET_TYPE_KERNEL_ARG(int, kernel_h)
-	CL_SET_TYPE_KERNEL_ARG(int, kernel_w)
-	CL_SET_TYPE_KERNEL_ARG(int, stride_h)
-	CL_SET_TYPE_KERNEL_ARG(int, stride_w)
-	CL_SET_TYPE_KERNEL_ARG(int, pad_h)
-	CL_SET_TYPE_KERNEL_ARG(int, pad_w)
-	CL_SET_ARRAY_KERNEL_ARG(&bottom_diff)
+  CL_SET_TYPE_KERNEL_ARG(int, nthreads, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&top_diff, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, num, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, channels, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, height, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, width, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, pooled_height, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, pooled_width, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, kernel_h, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, kernel_w, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, stride_h, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, stride_w, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, pad_h, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, pad_w, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&bottom_diff, kernel)
 
 	size_t global = CAFFE_GET_GLOBAL_WORKITEMS(nthreads, OPENCL_LOCAL_SIZE);
 	size_t local  = CAFFE_GET_LOCAL_WORKITEMS(nthreads, OPENCL_LOCAL_SIZE);
 
 	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+    LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<device.name()<<" : "<<caffe::OpenCL::what(err);
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<device.name();
 
 	CL_SET_KERNEL_ARG_END
 
@@ -471,46 +473,47 @@ bool clStoPoolBackward(
 		const int stride_h,
 		const int stride_w,
 		T* bottom_diff) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
 	std::string kernel_name = clGetKernelName<T>("StoPoolBackward");
 
-	queue = gpu->getQueue();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
-	kernel = gpu->getKernel(kernel_name);
+  cl_kernel* kernel = device.getKernel(kernel_name);
 	if ( kernel == NULL ) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, nthreads)
-	CL_SET_ARRAY_KERNEL_ARG(&rand_idx)
-	CL_SET_ARRAY_KERNEL_ARG(&top_diff)
-	CL_SET_TYPE_KERNEL_ARG(int, num)
-	CL_SET_TYPE_KERNEL_ARG(int, channels)
-	CL_SET_TYPE_KERNEL_ARG(int, height)
-	CL_SET_TYPE_KERNEL_ARG(int, width)
-	CL_SET_TYPE_KERNEL_ARG(int, pooled_height)
-	CL_SET_TYPE_KERNEL_ARG(int, pooled_width)
-	CL_SET_TYPE_KERNEL_ARG(int, kernel_h)
-	CL_SET_TYPE_KERNEL_ARG(int, kernel_w)
-	CL_SET_TYPE_KERNEL_ARG(int, stride_h)
-	CL_SET_TYPE_KERNEL_ARG(int, stride_w)
-	CL_SET_ARRAY_KERNEL_ARG(&bottom_diff)
+  CL_SET_TYPE_KERNEL_ARG(int, nthreads, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&rand_idx, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&top_diff, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, num, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, channels, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, height, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, width, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, pooled_height, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, pooled_width, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, kernel_h, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, kernel_w, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, stride_h, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, stride_w, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&bottom_diff, kernel)
 
 	size_t global = CAFFE_GET_GLOBAL_WORKITEMS(nthreads, OPENCL_LOCAL_SIZE);
 	size_t local  = CAFFE_GET_LOCAL_WORKITEMS(nthreads, OPENCL_LOCAL_SIZE);
 
 	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+    LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<device.name()<<" : "<<caffe::OpenCL::what(err);
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<device.name();
 
 	CL_SET_KERNEL_ARG_END
 
@@ -539,38 +542,39 @@ bool clMaxPoolForward(
 		int* mask,
 		T* top_mask
 		) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
 	std::string	kernel_name = clGetKernelName<T>("MaxPoolForward");
 
-	queue = gpu->getQueue();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
-	kernel = gpu->getKernel(kernel_name);
+  cl_kernel* kernel = device.getKernel(kernel_name);
 	if ( kernel == NULL ) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, nthreads)
-	CL_SET_ARRAY_KERNEL_ARG(&bottom_data)
-	CL_SET_TYPE_KERNEL_ARG(int, num)
-	CL_SET_TYPE_KERNEL_ARG(int, channels)
-	CL_SET_TYPE_KERNEL_ARG(int, height)
-	CL_SET_TYPE_KERNEL_ARG(int, width)
-	CL_SET_TYPE_KERNEL_ARG(int, pooled_height)
-	CL_SET_TYPE_KERNEL_ARG(int, pooled_width)
-	CL_SET_TYPE_KERNEL_ARG(int, kernel_h)
-	CL_SET_TYPE_KERNEL_ARG(int, kernel_w)
-	CL_SET_TYPE_KERNEL_ARG(int, stride_h)
-	CL_SET_TYPE_KERNEL_ARG(int, stride_w)
-	CL_SET_TYPE_KERNEL_ARG(int, pad_h)
-	CL_SET_TYPE_KERNEL_ARG(int, pad_w)
-	CL_SET_ARRAY_KERNEL_ARG(&top_data)
-	CL_SET_ARRAY_KERNEL_ARG(&mask)
-	CL_SET_ARRAY_KERNEL_ARG(&top_mask)
+  CL_SET_TYPE_KERNEL_ARG(int, nthreads, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&bottom_data, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, num, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, channels, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, height, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, width, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, pooled_height, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, pooled_width, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, kernel_h, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, kernel_w, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, stride_h, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, stride_w, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, pad_h, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, pad_w, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&top_data, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&mask, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&top_mask, kernel)
 
 
 	int dim = 1;
@@ -598,11 +602,11 @@ bool clMaxPoolForward(
 	std::string function = __func__;
 	err = clEnqueueNDRangeKernel(*queue, *kernel, dim, NULL, global, local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+    LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<device.name()<<" : "<<caffe::OpenCL::what(err);
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<device.name();
 
 	CL_SET_KERNEL_ARG_END
 
@@ -664,36 +668,37 @@ bool clAvePoolForward(
 		const int pad_h,
 		const int pad_w,
 		T* top_data) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
 	std::string kernel_name = clGetKernelName<T>("AvePoolForward");
 
-	queue = gpu->getQueue();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
-	kernel = gpu->getKernel(kernel_name);
+  cl_kernel* kernel = device.getKernel(kernel_name);
 	if ( kernel == NULL ) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, nthreads)
-	CL_SET_ARRAY_KERNEL_ARG(&bottom_data)
-	CL_SET_TYPE_KERNEL_ARG(int, num)
-	CL_SET_TYPE_KERNEL_ARG(int, channels)
-	CL_SET_TYPE_KERNEL_ARG(int, height)
-	CL_SET_TYPE_KERNEL_ARG(int, width)
-	CL_SET_TYPE_KERNEL_ARG(int, pooled_height)
-	CL_SET_TYPE_KERNEL_ARG(int, pooled_width)
-	CL_SET_TYPE_KERNEL_ARG(int, kernel_h)
-	CL_SET_TYPE_KERNEL_ARG(int, kernel_w)
-	CL_SET_TYPE_KERNEL_ARG(int, stride_h)
-	CL_SET_TYPE_KERNEL_ARG(int, stride_w)
-	CL_SET_TYPE_KERNEL_ARG(int, pad_h)
-	CL_SET_TYPE_KERNEL_ARG(int, pad_w)
-	CL_SET_ARRAY_KERNEL_ARG(&top_data)
+  CL_SET_TYPE_KERNEL_ARG(int, nthreads, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&bottom_data, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, num, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, channels, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, height, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, width, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, pooled_height, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, pooled_width, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, kernel_h, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, kernel_w, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, stride_h, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, stride_w, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, pad_h, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, pad_w, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&top_data, kernel)
 
 	int dim = 1;
 	size_t *global;
@@ -719,11 +724,11 @@ bool clAvePoolForward(
 
 	err = clEnqueueNDRangeKernel(*queue, *kernel, dim, NULL, global, local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+    LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<device.name()<<" : "<<caffe::OpenCL::what(err);
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<device.name();
 
 	CL_SET_KERNEL_ARG_END
 
@@ -748,46 +753,47 @@ bool clStoPoolForwardTrain(
 		const int stride_w,
 		T* rand_idx,
 		T* top_data) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
 	std::string kernel_name = clGetKernelName<T>("StoPoolForwardTrain");
 
-	queue = gpu->getQueue();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
-	kernel = gpu->getKernel(kernel_name);
+  cl_kernel* kernel = device.getKernel(kernel_name);
 	if ( kernel == NULL ) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, nthreads)
-	CL_SET_ARRAY_KERNEL_ARG(&bottom_data)
-	CL_SET_TYPE_KERNEL_ARG(int, num)
-	CL_SET_TYPE_KERNEL_ARG(int, channels)
-	CL_SET_TYPE_KERNEL_ARG(int, height)
-	CL_SET_TYPE_KERNEL_ARG(int, width)
-	CL_SET_TYPE_KERNEL_ARG(int, pooled_height)
-	CL_SET_TYPE_KERNEL_ARG(int, pooled_width)
-	CL_SET_TYPE_KERNEL_ARG(int, kernel_h)
-	CL_SET_TYPE_KERNEL_ARG(int, kernel_w)
-	CL_SET_TYPE_KERNEL_ARG(int, stride_h)
-	CL_SET_TYPE_KERNEL_ARG(int, stride_w)
-	CL_SET_ARRAY_KERNEL_ARG(&rand_idx)
-	CL_SET_ARRAY_KERNEL_ARG(&top_data)
+  CL_SET_TYPE_KERNEL_ARG(int, nthreads, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&bottom_data, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, num, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, channels, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, height, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, width, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, pooled_height, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, pooled_width, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, kernel_h, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, kernel_w, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, stride_h, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, stride_w, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&rand_idx, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&top_data, kernel)
 
 	size_t global = CAFFE_GET_GLOBAL_WORKITEMS(nthreads, OPENCL_LOCAL_SIZE);
 	size_t local  = CAFFE_GET_LOCAL_WORKITEMS(nthreads, OPENCL_LOCAL_SIZE);
 
 	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+    LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<device.name()<<" : "<<caffe::OpenCL::what(err);
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<device.name();
 
 	CL_SET_KERNEL_ARG_END
 
@@ -811,45 +817,46 @@ bool clStoPoolForwardTest(
 		const int stride_h,
 		const int stride_w,
 		T* top_data) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
 	std::string kernel_name = clGetKernelName<T>("StoPoolForwardTest");
 
-	queue = gpu->getQueue();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
-	kernel = gpu->getKernel(kernel_name);
+  cl_kernel* kernel = device.getKernel(kernel_name);
 	if ( kernel == NULL ) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, nthreads)
-	CL_SET_ARRAY_KERNEL_ARG(&bottom_data)
-	CL_SET_TYPE_KERNEL_ARG(int, num)
-	CL_SET_TYPE_KERNEL_ARG(int, channels)
-	CL_SET_TYPE_KERNEL_ARG(int, height)
-	CL_SET_TYPE_KERNEL_ARG(int, width)
-	CL_SET_TYPE_KERNEL_ARG(int, pooled_height)
-	CL_SET_TYPE_KERNEL_ARG(int, pooled_width)
-	CL_SET_TYPE_KERNEL_ARG(int, kernel_h)
-	CL_SET_TYPE_KERNEL_ARG(int, kernel_w)
-	CL_SET_TYPE_KERNEL_ARG(int, stride_h)
-	CL_SET_TYPE_KERNEL_ARG(int, stride_w)
-	CL_SET_ARRAY_KERNEL_ARG(&top_data)
+  CL_SET_TYPE_KERNEL_ARG(int, nthreads, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&bottom_data, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, num, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, channels, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, height, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, width, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, pooled_height, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, pooled_width, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, kernel_h, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, kernel_w, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, stride_h, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, stride_w, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&top_data, kernel)
 
 	size_t global = CAFFE_GET_GLOBAL_WORKITEMS(nthreads, OPENCL_LOCAL_SIZE);
 	size_t local  = CAFFE_GET_LOCAL_WORKITEMS(nthreads, OPENCL_LOCAL_SIZE);
 
 	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+    LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<device.name()<<" : "<<caffe::OpenCL::what(err);
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<device.name();
 
 	CL_SET_KERNEL_ARG_END
 

--- a/src/caffe/layers/relu_layer.cpp
+++ b/src/caffe/layers/relu_layer.cpp
@@ -47,36 +47,37 @@ namespace OpenCL {
 
 template<typename T>
 bool clReLULayerForward(const int count, const T* bottom_data, T* top_data, T negative_slope) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
+  cl_command_queue* queue = device.getQueue();
 
 	std::string kernel_name = clGetKernelName<T>("ReLUForward");
 
-	queue = gpu->getQueue();
-	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+  if ( ! queue ) {
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
-	kernel = gpu->getKernel(kernel_name);
+  cl_kernel* kernel = device.getKernel(kernel_name);
 	if ( kernel == NULL ) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, count)
-	CL_SET_ARRAY_KERNEL_ARG(&bottom_data)
-	CL_SET_ARRAY_KERNEL_ARG(&top_data)
-	CL_SET_TYPE_KERNEL_ARG(T, negative_slope)
+  CL_SET_TYPE_KERNEL_ARG(int, count, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&bottom_data, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&top_data, kernel)
+  CL_SET_TYPE_KERNEL_ARG(T, negative_slope, kernel)
 
 	size_t global = CAFFE_GET_GLOBAL_WORKITEMS(count, OPENCL_LOCAL_SIZE);
 	size_t local  = CAFFE_GET_LOCAL_WORKITEMS(count, OPENCL_LOCAL_SIZE);
 
 	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+    LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<device.name()<<" : "<<caffe::OpenCL::what(err);
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<device.name();
 
 	CL_SET_KERNEL_ARG_END
 
@@ -87,37 +88,38 @@ template bool clReLULayerForward<double>(const int count, const double* bottom_d
 
 template<typename T>
 bool clReLULayerBackward(const int count, const T* top_diff, const T* bottom_data, T* bottom_diff, T negative_slope) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
 	std::string kernel_name = clGetKernelName<T>("ReLUBackward");
 
-	queue = gpu->getQueue();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
-	kernel = gpu->getKernel(kernel_name);
+  cl_kernel* kernel = device.getKernel(kernel_name);
 	if ( kernel == NULL ) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, count)
-	CL_SET_ARRAY_KERNEL_ARG(&top_diff)
-	CL_SET_ARRAY_KERNEL_ARG(&bottom_data)
-	CL_SET_ARRAY_KERNEL_ARG(&bottom_diff)
-	CL_SET_TYPE_KERNEL_ARG(T, negative_slope)
+  CL_SET_TYPE_KERNEL_ARG(int, count, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&top_diff, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&bottom_data, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&bottom_diff, kernel)
+  CL_SET_TYPE_KERNEL_ARG(T, negative_slope, kernel)
 
 	size_t global = CAFFE_GET_GLOBAL_WORKITEMS(count, OPENCL_LOCAL_SIZE);
 	size_t local  = CAFFE_GET_LOCAL_WORKITEMS(count, OPENCL_LOCAL_SIZE);
 
 	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+    LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<device.name()<<" : "<<caffe::OpenCL::what(err);
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<device.name();
 
 	CL_SET_KERNEL_ARG_END
 

--- a/src/caffe/layers/sigmoid_layer.cpp
+++ b/src/caffe/layers/sigmoid_layer.cpp
@@ -50,35 +50,33 @@ namespace OpenCL {
 
 template<typename T>
 bool clSigmoidLayerForward(const int count, const T* bottom_data, T* top_data) {
-
-	std::string kernel_name = clGetKernelName<T>("SigmoidForward");
-
-	queue = gpu->getQueue();
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
-
-	kernel = gpu->getKernel(kernel_name);
+  std::string kernel_name = clGetKernelName<T>("SigmoidForward");
+  cl_kernel* kernel = device.getKernel(kernel_name);
 	if ( kernel == NULL ) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, count)
-	CL_SET_ARRAY_KERNEL_ARG(&bottom_data)
-	CL_SET_ARRAY_KERNEL_ARG(&top_data)
+  CL_SET_TYPE_KERNEL_ARG(int, count, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&bottom_data, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&top_data, kernel)
 
 	size_t global = CAFFE_GET_GLOBAL_WORKITEMS(count, OPENCL_LOCAL_SIZE);
 	size_t local  = CAFFE_GET_LOCAL_WORKITEMS(count, OPENCL_LOCAL_SIZE);
 
 	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+    LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<< device.name()<<" : "<<caffe::OpenCL::what(err);
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<device.name();
 
 	CL_SET_KERNEL_ARG_END
 
@@ -89,36 +87,37 @@ template bool clSigmoidLayerForward<double>(const int count, const double* botto
 
 template<typename T>
 bool clSigmoidLayerBackward(const int count, const T* top_diff, const T* top_data, T* bottom_diff) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
 	std::string kernel_name = clGetKernelName<T>("SigmoidBackward");
 
-	queue = gpu->getQueue();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
-	kernel = gpu->getKernel(kernel_name);
+  cl_kernel* kernel = device.getKernel(kernel_name);
 	if ( kernel == NULL ) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, count)
-	CL_SET_ARRAY_KERNEL_ARG(&top_diff)
-	CL_SET_ARRAY_KERNEL_ARG(&top_data)
-	CL_SET_ARRAY_KERNEL_ARG(&bottom_diff)
+  CL_SET_TYPE_KERNEL_ARG(int, count, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&top_diff, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&top_data, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&bottom_diff, kernel)
 
 	size_t global = CAFFE_GET_GLOBAL_WORKITEMS(count, OPENCL_LOCAL_SIZE);
 	size_t local  = CAFFE_GET_LOCAL_WORKITEMS(count, OPENCL_LOCAL_SIZE);
 
 	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+    LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<< device.name()<<" : "<<caffe::OpenCL::what(err);
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '" << kernel_name <<"' executed on GPU "<<device.name();
 
 	CL_SET_KERNEL_ARG_END
 

--- a/src/caffe/layers/softmax_layer.cpp
+++ b/src/caffe/layers/softmax_layer.cpp
@@ -97,37 +97,41 @@ namespace OpenCL {
 
 template<typename T>
 bool clkernel_channel_max(const int num, const int channels, const int spatial_dim, const T* data, T* out) {
-
+  OpenCLDevice& current_device = OpenCLManager::CurrentPlatform().CurrentDevice();
 	std::string kernel_name = clGetKernelName<T>("kernel_channel_max");
 
-	queue = gpu->getQueue();
-	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+  cl_command_queue* queue = current_device.getQueue();
+  if (!queue) {
+    LOG(ERROR) << current_device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
-	kernel = gpu->getKernel(kernel_name);
+  cl_kernel* kernel = current_device.getKernel(kernel_name);
 	if ( kernel == NULL ) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, num)
-	CL_SET_TYPE_KERNEL_ARG(int, channels)
-	CL_SET_TYPE_KERNEL_ARG(int, spatial_dim)
-	CL_SET_ARRAY_KERNEL_ARG(&data)
-	CL_SET_ARRAY_KERNEL_ARG(&out)
+  CL_SET_TYPE_KERNEL_ARG(int, num, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, channels, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, spatial_dim, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&data, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&out, kernel)
 
 	size_t global = CAFFE_GET_GLOBAL_WORKITEMS(num*spatial_dim, OPENCL_LOCAL_SIZE);
 	size_t local  = CAFFE_GET_LOCAL_WORKITEMS(num*spatial_dim, OPENCL_LOCAL_SIZE);
 
-	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
+  err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL,
+                               &global, &local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+    LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()
+               <<"' on GPU " << current_device.name()
+               <<" : " << caffe::OpenCL::what(err);
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "
+             << current_device.name();
 
 	CL_SET_KERNEL_ARG_END
 
@@ -137,38 +141,41 @@ template bool clkernel_channel_max<float>(const int num, const int channels, con
 template bool clkernel_channel_max<double>(const int num, const int channels, const int spatial_dim, const double* data, double* out);
 
 template<typename T>
-bool clkernel_channel_subtract(const int num, const int channels, const int spatial_dim, T* data, const T* channel_max) {
-
+bool clkernel_channel_subtract(const int num, const int channels, const int spatial_dim,
+                               T* data, const T* channel_max) {
+  OpenCLDevice& current_device = OpenCLManager::CurrentPlatform().CurrentDevice();
 	std::string kernel_name = clGetKernelName<T>("kernel_channel_subtract");
-
-	queue = gpu->getQueue();
-	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+  cl_command_queue* queue = current_device.getQueue();
+  if (!queue) {
+    LOG(ERROR) << current_device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
-	kernel = gpu->getKernel(kernel_name);
-	if ( kernel == NULL ) {
+  cl_kernel* kernel = current_device.getKernel(kernel_name);
+  if (kernel == NULL) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, num)
-	CL_SET_TYPE_KERNEL_ARG(int, channels)
-	CL_SET_TYPE_KERNEL_ARG(int, spatial_dim)
-	CL_SET_ARRAY_KERNEL_ARG(&data)
-	CL_SET_ARRAY_KERNEL_ARG(&channel_max)
+  CL_SET_TYPE_KERNEL_ARG(int, num, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, channels, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, spatial_dim, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&data, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&channel_max, kernel)
 
 	size_t global = CAFFE_GET_GLOBAL_WORKITEMS(num*spatial_dim, OPENCL_LOCAL_SIZE);
 	size_t local  = CAFFE_GET_LOCAL_WORKITEMS(num*spatial_dim, OPENCL_LOCAL_SIZE);
 
 	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+    LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()
+               <<"' on GPU " << current_device.name()
+              <<" : "<<caffe::OpenCL::what(err);
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '" << kernel_name.c_str()
+             << "' executed on GPU " << current_device.name();
 
 	CL_SET_KERNEL_ARG_END
 
@@ -179,35 +186,40 @@ template bool clkernel_channel_subtract<double>(const int num, const int channel
 
 template<typename T>
 bool clkernel_exp(const int count, const T* data, T* out) {
-
+  OpenCLDevice& current_device =
+      OpenCLManager::CurrentPlatform().CurrentDevice();
 	std::string kernel_name = clGetKernelName<T>("kernel_exp");
-
-	queue = gpu->getQueue();
-	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+  cl_command_queue* queue = current_device.getQueue();
+  if (!queue) {
+    LOG(ERROR) << current_device.name()
+               << "> failed to get OpenCL command queue";
 		return false;
 	}
 
-	kernel = gpu->getKernel(kernel_name);
-	if ( kernel == NULL ) {
+  cl_kernel* kernel = current_device.getKernel(kernel_name);
+  if (kernel == NULL) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, count)
-	CL_SET_ARRAY_KERNEL_ARG(&data)
-	CL_SET_ARRAY_KERNEL_ARG(&out)
+  CL_SET_TYPE_KERNEL_ARG(int, count, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&data, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&out, kernel)
 
 	size_t global = CAFFE_GET_GLOBAL_WORKITEMS(count, OPENCL_LOCAL_SIZE);
 	size_t local  = CAFFE_GET_LOCAL_WORKITEMS(count, OPENCL_LOCAL_SIZE);
 
-	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
+  err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL,
+                               &global, &local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+    LOG(ERROR) << "Failed to enqueue kernel '"
+               << kernel_name.c_str()<<"' on GPU "
+               << current_device.name()<<" : " << caffe::OpenCL::what(err);
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '" << kernel_name
+             << "' executed on GPU " << current_device.name();
 
 	CL_SET_KERNEL_ARG_END
 
@@ -218,134 +230,175 @@ template bool clkernel_exp<double>(const int count, const double* data, double* 
 
 template<typename T>
 bool clkernel_channel_sum(const int num, const int channels, const int spatial_dim, const T* data, T* channel_sum) {
-
+  OpenCLDevice& current_device = OpenCLManager::CurrentPlatform().CurrentDevice();
 	std::string kernel_name = clGetKernelName<T>("kernel_channel_sum");
-
-	queue = gpu->getQueue();
-	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+  cl_command_queue* queue = current_device.getQueue();
+  if (!queue) {
+    LOG(ERROR) << current_device.name()
+               << "> failed to get OpenCL command queue";
 		return false;
 	}
 
-	kernel = gpu->getKernel(kernel_name);
+  cl_kernel* kernel = current_device.getKernel(kernel_name);
 	if ( kernel == NULL ) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, num)
-	CL_SET_TYPE_KERNEL_ARG(int, channels)
-	CL_SET_TYPE_KERNEL_ARG(int, spatial_dim)
-	CL_SET_ARRAY_KERNEL_ARG(&data)
-	CL_SET_ARRAY_KERNEL_ARG(&channel_sum)
+  CL_SET_TYPE_KERNEL_ARG(int, num, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, channels, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, spatial_dim, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&data, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&channel_sum, kernel)
 
 	size_t global = CAFFE_GET_GLOBAL_WORKITEMS(num*spatial_dim, OPENCL_LOCAL_SIZE);
 	size_t local  = CAFFE_GET_LOCAL_WORKITEMS(num*spatial_dim, OPENCL_LOCAL_SIZE);
 
-	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
+  err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL,
+                               &global, &local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+    LOG(ERROR) << "Failed to enqueue kernel '"
+               << kernel_name.c_str() << "' on GPU "
+               << current_device.name()
+               << " : "<<caffe::OpenCL::what(err);
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '" << kernel_name
+             << "' executed on GPU " << current_device.name();
 
 	CL_SET_KERNEL_ARG_END
 
 	return true;
 }
-template bool clkernel_channel_sum<float>(const int num, const int channels, const int spatial_dim, const float* data, float* channel_sum);
-template bool clkernel_channel_sum<double>(const int num, const int channels, const int spatial_dim, const double* data, double* channel_sum);
+template bool clkernel_channel_sum<float>(
+                        const int num, const int channels,
+                        const int spatial_dim, const float* data,
+                        float* channel_sum);
+template bool clkernel_channel_sum<double>(
+                        const int num, const int channels,
+                        const int spatial_dim, const double* data,
+                        double* channel_sum);
 
 template<typename T>
-bool clkernel_channel_div(const int num, const int channels, const int spatial_dim, T* data, const T* channel_sum) {
-
+bool clkernel_channel_div(const int num, const int channels,
+                          const int spatial_dim,
+                          T* data, const T* channel_sum) {
+  OpenCLDevice& current_device =
+      OpenCLManager::CurrentPlatform().CurrentDevice();
 	std::string kernel_name = clGetKernelName<T>("kernel_channel_div");
-
-	queue = gpu->getQueue();
-	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+  cl_command_queue* queue = current_device.getQueue();
+  if (!queue) {
+    LOG(ERROR) << current_device.name()
+               << "> failed to get OpenCL command queue";
 		return false;
 	}
 
-	kernel = gpu->getKernel(kernel_name);
-	if ( kernel == NULL ) {
+  cl_kernel* kernel = current_device.getKernel(kernel_name);
+  if (kernel == NULL) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, num)
-	CL_SET_TYPE_KERNEL_ARG(int, channels)
-	CL_SET_TYPE_KERNEL_ARG(int, spatial_dim)
-	CL_SET_ARRAY_KERNEL_ARG(&data)
-	CL_SET_ARRAY_KERNEL_ARG(&channel_sum)
+  CL_SET_TYPE_KERNEL_ARG(int, num, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, channels, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, spatial_dim, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&data, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&channel_sum, kernel)
 
-	size_t global = CAFFE_GET_GLOBAL_WORKITEMS(num*spatial_dim, OPENCL_LOCAL_SIZE);
-	size_t local  = CAFFE_GET_LOCAL_WORKITEMS(num*spatial_dim, OPENCL_LOCAL_SIZE);
+  size_t global = CAFFE_GET_GLOBAL_WORKITEMS(num*spatial_dim,
+                                             OPENCL_LOCAL_SIZE);
+  size_t local  = CAFFE_GET_LOCAL_WORKITEMS(num*spatial_dim,
+                                            OPENCL_LOCAL_SIZE);
 
-	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
+  err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL,
+                               &global, &local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+    LOG(ERROR) << "Failed to enqueue kernel '"
+               << kernel_name << "' on GPU " << current_device.name()
+               << " : "<<caffe::OpenCL::what(err);
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '" << kernel_name
+             << "' executed on GPU " << current_device.name();
 
 	CL_SET_KERNEL_ARG_END
 
 	return true;
 }
-template bool clkernel_channel_div<float>(const int num, const int channels, const int spatial_dim, float* data, const float* channel_sum);
-template bool clkernel_channel_div<double>(const int num, const int channels, const int spatial_dim, double* data, const double* channel_sum);
+template bool clkernel_channel_div<float>(const int num,
+              const int channels, const int spatial_dim,
+              float* data, const float* channel_sum);
+template bool clkernel_channel_div<double>(const int num,
+              const int channels, const int spatial_dim,
+              double* data, const double* channel_sum);
 
 template<typename T>
-bool clkernel_channel_dot(const int num, const int channels, const int spatial_dim, const T* data_1, const T* data_2, T* channel_dot) {
-
+bool clkernel_channel_dot(const int num, const int channels,
+                          const int spatial_dim, const T* data_1,
+                          const T* data_2, T* channel_dot) {
+  OpenCLDevice& current_device =
+      OpenCLManager::CurrentPlatform().CurrentDevice();
 	std::string kernel_name = clGetKernelName<T>("kernel_channel_dot");
-
-	queue = gpu->getQueue();
-	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+  cl_command_queue* queue = current_device.getQueue();
+  if (!queue) {
+    LOG(ERROR) << current_device.name()
+               << "> failed to get OpenCL command queue";
 		return false;
 	}
 
-	kernel = gpu->getKernel(kernel_name);
-	if ( kernel == NULL ) {
+  cl_kernel* kernel = current_device.getKernel(kernel_name);
+  if (kernel == NULL) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, num)
-	CL_SET_TYPE_KERNEL_ARG(int, channels)
-	CL_SET_TYPE_KERNEL_ARG(int, spatial_dim)
-	CL_SET_ARRAY_KERNEL_ARG(&data_1)
-	CL_SET_ARRAY_KERNEL_ARG(&data_2)
-	CL_SET_ARRAY_KERNEL_ARG(&channel_dot)
+  CL_SET_TYPE_KERNEL_ARG(int, num, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, channels, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, spatial_dim, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&data_1, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&data_2, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&channel_dot, kernel)
 
-	size_t global = CAFFE_GET_GLOBAL_WORKITEMS(num*spatial_dim, OPENCL_LOCAL_SIZE);
-	size_t local  = CAFFE_GET_LOCAL_WORKITEMS(num*spatial_dim, OPENCL_LOCAL_SIZE);
+  size_t global = CAFFE_GET_GLOBAL_WORKITEMS(num*spatial_dim,
+                                             OPENCL_LOCAL_SIZE);
+  size_t local  = CAFFE_GET_LOCAL_WORKITEMS(num*spatial_dim,
+                                            OPENCL_LOCAL_SIZE);
 
-	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
-	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+  err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global,
+                               &local, 0, NULL, NULL);
+  if (err != CL_SUCCESS) {
+    LOG(ERROR) << "Failed to enqueue kernel '"
+               << kernel_name
+               << "' on GPU " << current_device.name()
+               <<" : "<<caffe::OpenCL::what(err);
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '"<<kernel_name.c_str()
+             <<"' executed on GPU " << current_device.name();
 
 	CL_SET_KERNEL_ARG_END
 
 	return true;
 }
-template bool clkernel_channel_dot<float>(const int num, const int channels, const int spatial_dim, const float* data_1, const float* data_2, float* channel_dot);
-template bool clkernel_channel_dot<double>(const int num, const int channels, const int spatial_dim, const double* data_1, const double* data_2, double* channel_dot);
-
-
+template bool clkernel_channel_dot<float>(const int num, const int channels,
+                                          const int spatial_dim,
+                                          const float* data_1,
+                                          const float* data_2,
+                                          float* channel_dot);
+template bool clkernel_channel_dot<double>(const int num, const int channels,
+                                           const int spatial_dim,
+                                           const double* data_1,
+                                           const double* data_2,
+                                           double* channel_dot);
 } // namespace OpenCL
 
 
 template<typename Dtype>
-void SoftmaxLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+void SoftmaxLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+                                      const vector<Blob<Dtype>*>& top) {
 	const Dtype* bottom_data = bottom[0]->gpu_data();
 	Dtype* top_data = (top)[0]->mutable_gpu_data();
 	Dtype* scale_data = scale_.mutable_gpu_data();
@@ -385,19 +438,27 @@ void SoftmaxLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom, const 
 	 scale_data);
 	 */
 
-	 BOOL_CHECK( caffe::OpenCL::clkernel_channel_max(num, channels, spatial_dim, top_data, scale_data) );
+   BOOL_CHECK( caffe::OpenCL::clkernel_channel_max(num, channels, spatial_dim,
+                                                   top_data, scale_data) );
 	 // subtract
-	 BOOL_CHECK( caffe::OpenCL::clkernel_channel_subtract(num, channels, spatial_dim, top_data, scale_data) );
+   BOOL_CHECK( caffe::OpenCL::clkernel_channel_subtract(num, channels,
+                                                        spatial_dim, top_data,
+                                                        scale_data) );
 	 // exponentiate
-	 BOOL_CHECK( caffe::OpenCL::clkernel_exp(num * channels * spatial_dim, top_data, top_data) );
+   BOOL_CHECK( caffe::OpenCL::clkernel_exp(num * channels * spatial_dim,
+                                           top_data, top_data) );
 	 // sum after exp
-	 BOOL_CHECK( caffe::OpenCL::clkernel_channel_sum(num, channels, spatial_dim, top_data, scale_data) );
+   BOOL_CHECK( caffe::OpenCL::clkernel_channel_sum(num, channels, spatial_dim,
+                                                   top_data, scale_data) );
 	 // divide
-	 BOOL_CHECK( caffe::OpenCL::clkernel_channel_div(num, channels, spatial_dim, top_data, scale_data) );
+   BOOL_CHECK( caffe::OpenCL::clkernel_channel_div(num, channels, spatial_dim,
+                                                   top_data, scale_data) );
 }
 
 template<typename Dtype>
-void SoftmaxLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top, const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+void SoftmaxLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
+                                       const vector<bool>& propagate_down,
+                                       const vector<Blob<Dtype>*>& bottom) {
 	const Dtype* top_diff = top[0]->gpu_diff();
 	const Dtype* top_data = top[0]->gpu_data();
 	Dtype* bottom_diff = (bottom)[0]->mutable_gpu_diff();

--- a/src/caffe/layers/tanh_layer.cpp
+++ b/src/caffe/layers/tanh_layer.cpp
@@ -48,35 +48,35 @@ namespace OpenCL {
 
 template<typename T>
 bool clTanHLayerForward(const int count, const T* bottom_data, T* top_data) {
-
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 	std::string kernel_name = clGetKernelName<T>("TanHForward");
 
-	queue = gpu->getQueue();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
-	kernel = gpu->getKernel(kernel_name);
+  cl_kernel* kernel = device.getKernel(kernel_name);
 	if ( kernel == NULL ) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, count)
-	CL_SET_ARRAY_KERNEL_ARG(&bottom_data)
-	CL_SET_ARRAY_KERNEL_ARG(&top_data)
+  CL_SET_TYPE_KERNEL_ARG(int, count, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&bottom_data, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&top_data, kernel)
 
 	size_t global = CAFFE_GET_GLOBAL_WORKITEMS(count, OPENCL_LOCAL_SIZE);
 	size_t local  = CAFFE_GET_LOCAL_WORKITEMS(count, OPENCL_LOCAL_SIZE);
 
 	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+    LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<< device.name()<<" : "<<caffe::OpenCL::what(err);
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<< device.name();
 
 	CL_SET_KERNEL_ARG_END
 
@@ -87,36 +87,37 @@ template bool clTanHLayerForward<double>(const int count, const double* bottom_d
 
 template<typename T>
 bool clTanHLayerBackward(const int count, const T* top_diff, const T* top_data, T* bottom_diff) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
 	std::string kernel_name = clGetKernelName<T>("TanHBackward");
 
-	queue = gpu->getQueue();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
-	kernel = gpu->getKernel(kernel_name);
+  cl_kernel* kernel = device.getKernel(kernel_name);
 	if ( kernel == NULL ) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, count)
-	CL_SET_ARRAY_KERNEL_ARG(&top_diff)
-	CL_SET_ARRAY_KERNEL_ARG(&top_data)
-	CL_SET_ARRAY_KERNEL_ARG(&bottom_diff)
+  CL_SET_TYPE_KERNEL_ARG(int, count, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&top_diff, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&top_data, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&bottom_diff, kernel)
 
 	size_t global = CAFFE_GET_GLOBAL_WORKITEMS(count, OPENCL_LOCAL_SIZE);
 	size_t local  = CAFFE_GET_LOCAL_WORKITEMS(count, OPENCL_LOCAL_SIZE);
 
 	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+    LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<< device.name()<<" : "<<caffe::OpenCL::what(err);
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<< device.name();
 
 	CL_SET_KERNEL_ARG_END
 

--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -14,7 +14,7 @@
 #include "caffe/util/math_functions.hpp"
 #include "caffe/util/upgrade_proto.hpp"
 
-#include "caffe/test/test_caffe_main.hpp"
+//#include "caffe/test/test_caffe_main.hpp"
 
 namespace caffe {
 

--- a/src/caffe/test/test_OpenCL.cpp
+++ b/src/caffe/test/test_OpenCL.cpp
@@ -68,36 +68,42 @@ TYPED_TEST(OpenCLSimpleTest, TestMaxMemory) {
 	printf("OpenCL successfully released %d buffers of 1MB\n", suc_cnt);
 }
 
-//TYPED_TEST(OpenCLSimpleTest, TestMaxBuffer) {
-//	size_t MB 			= 1024*1024;
-//	size_t alloc		= MB;
-//	int max_cnt			= 100000;
-//	int suc_cnt			= 0;
+TYPED_TEST(OpenCLSimpleTest, TestMaxBuffer) {
+  size_t MB 			= 1024*1024;
+  long int alloc_increment
+                  = 100 * MB;
+  size_t alloc		= alloc_increment;
+  int max_cnt			= 1000;
+  int suc_cnt			= 0;
 
-//	float pattern = 0.0;
-//	void* vPtr 		= NULL;
+  float pattern = 0.0;
+  void* vPtr 		= NULL;
 
-//	int i = 0;
-//	for(i = 0; i < max_cnt; i++ ) {
-//		if ( ! caffe::OpenCL::clMalloc(&vPtr, alloc) ) {
-//	    break;
-//		}
-//    try {
-//			caffe::OpenCL::clMemset(vPtr, pattern, alloc);
-//		} catch (std::exception &e) {
-//			break;
-//		}
-//		suc_cnt++;
-//    if ( suc_cnt % 1024 == 0 ) {
-//      printf("OpenCL succesfully allocated 1 buffer of %dMB\n", suc_cnt);
-//    }
+  int i = 0;
+  for(i = 0; i < max_cnt; i++ ) {
+    if ( ! caffe::OpenCL::clMalloc(&vPtr, alloc) ) {
+      break;
+    }
+    try {
+      caffe::OpenCL::clMemset(vPtr, pattern, alloc);
+    } catch (std::exception &e) {
+      break;
+    }
+    suc_cnt++;
 
-//		alloc += MB;
-//		EXPECT_TRUE(caffe::OpenCL::clFree(vPtr));
-//	}
-//	printf("OpenCL successfully allocated one buffer of %d MB\n", suc_cnt);
+    if (suc_cnt % 10 == 0)
+    {
+      printf("OpenCL succesfully allocated 1 buffer of %ldMB\n",
+             suc_cnt * alloc_increment / MB);
+    }
 
-//}
+    alloc += alloc_increment;
+    EXPECT_TRUE(caffe::OpenCL::clFree(vPtr));
+  }
+  long int megabytes= suc_cnt * alloc_increment / MB;
+  printf("OpenCL successfully allocated one buffer of %ld MB\n", megabytes);
+
+}
 
 TYPED_TEST(OpenCLSimpleTest, TestMemcpy) {
 

--- a/src/caffe/test/test_OpenCL.cpp
+++ b/src/caffe/test/test_OpenCL.cpp
@@ -68,36 +68,36 @@ TYPED_TEST(OpenCLSimpleTest, TestMaxMemory) {
 	printf("OpenCL successfully released %d buffers of 1MB\n", suc_cnt);
 }
 
-TYPED_TEST(OpenCLSimpleTest, TestMaxBuffer) {
-	size_t MB 			= 1024*1024;
-	size_t alloc		= MB;
-	int max_cnt			= 100000;
-	int suc_cnt			= 0;
+//TYPED_TEST(OpenCLSimpleTest, TestMaxBuffer) {
+//	size_t MB 			= 1024*1024;
+//	size_t alloc		= MB;
+//	int max_cnt			= 100000;
+//	int suc_cnt			= 0;
 
-	float pattern = 0.0;
-	void* vPtr 		= NULL;
+//	float pattern = 0.0;
+//	void* vPtr 		= NULL;
 
-	int i = 0;
-	for(i = 0; i < max_cnt; i++ ) {
-		if ( ! caffe::OpenCL::clMalloc(&vPtr, alloc) ) {
-	    break;
-		}
-    try {
-			caffe::OpenCL::clMemset(vPtr, pattern, alloc);
-		} catch (std::exception &e) {
-			break;
-		}
-		suc_cnt++;
-    if ( suc_cnt % 1024 == 0 ) {
-      printf("OpenCL succesfully allocated 1 buffer of %dMB\n", suc_cnt);
-    }
+//	int i = 0;
+//	for(i = 0; i < max_cnt; i++ ) {
+//		if ( ! caffe::OpenCL::clMalloc(&vPtr, alloc) ) {
+//	    break;
+//		}
+//    try {
+//			caffe::OpenCL::clMemset(vPtr, pattern, alloc);
+//		} catch (std::exception &e) {
+//			break;
+//		}
+//		suc_cnt++;
+//    if ( suc_cnt % 1024 == 0 ) {
+//      printf("OpenCL succesfully allocated 1 buffer of %dMB\n", suc_cnt);
+//    }
 
-		alloc += MB;
-		EXPECT_TRUE(caffe::OpenCL::clFree(vPtr));
-	}
-	printf("OpenCL successfully allocated one buffer of %d MB\n", suc_cnt);
+//		alloc += MB;
+//		EXPECT_TRUE(caffe::OpenCL::clFree(vPtr));
+//	}
+//	printf("OpenCL successfully allocated one buffer of %d MB\n", suc_cnt);
 
-}
+//}
 
 TYPED_TEST(OpenCLSimpleTest, TestMemcpy) {
 

--- a/src/caffe/test/test_caffe_main.cpp
+++ b/src/caffe/test/test_caffe_main.cpp
@@ -37,6 +37,11 @@ int main(int argc, char** argv) {
 #endif
 
 #ifdef USE_OPENCL
+  int device_id = 0;
+  if (argc > 1) {
+    device_id = atoi(argv[1]);
+  }
+  caffe::OpenCLManager::SetDeviceId(device_id);
   if ( ! caffe::OpenCLManager::Init() ) {
 	  LOG(ERROR) << "failed to initialize OpenCL";
 	  return 1;

--- a/src/caffe/test/test_caffe_main.cpp
+++ b/src/caffe/test/test_caffe_main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char** argv) {
 #endif
 
 #ifdef USE_OPENCL
-  if ( ! caffe::OpenCL::init() ) {
+  if ( ! caffe::OpenCLManager::Init() ) {
 	  LOG(ERROR) << "failed to initialize OpenCL";
 	  return 1;
   }

--- a/src/caffe/test/test_platform.cpp
+++ b/src/caffe/test/test_platform.cpp
@@ -55,7 +55,12 @@ TEST_F(PlatformTest, TestInitialization) {
 #endif
 
 #ifdef USE_OPENCL
-  EXPECT_TRUE( caffe::OpenCL::init() );
+  EXPECT_TRUE( caffe::OpenCLManager::Init() );
+  OpenCLManager::Print();
+  std::cout << "Current platform: =============================" << std::endl;
+  OpenCLManager::CurrentPlatform().print();
+  std::cout << "Current Device ================================" << std::endl;
+  OpenCLManager::CurrentPlatform().CurrentDevice().print();
 #endif
 }
 

--- a/src/caffe/util/OpenCL/OpenCLDevice.cpp
+++ b/src/caffe/util/OpenCL/OpenCLDevice.cpp
@@ -567,6 +567,12 @@ size_t OpenCLDevice::getMemoryUsage() {
 	return bytesUsed;
 }
 
+void OpenCLDevice::Synchronize() {
+  if (queue != NULL) {
+    clFinish(queue);
+  }
+}
+
 } // namespace caffe
 
 #endif //USE_OPENCL

--- a/src/caffe/util/OpenCL/OpenCLDevice.cpp
+++ b/src/caffe/util/OpenCL/OpenCLDevice.cpp
@@ -257,7 +257,6 @@ bool OpenCLDevice::createContext() {
 }
 
 bool OpenCLDevice::compile(std::string cl_source) {
-
 	if (context == NULL) {
 		LOG(ERROR)<< "cannot create OpenCL program without OpenCL context";
 		return false;
@@ -349,13 +348,13 @@ bool OpenCLDevice::compile(std::string cl_source) {
 			return false;
 		}
 
-		if ( kernel.find((*it)) != kernel.end() ) {
+    if ( kernel_map_.find((*it)) != kernel_map_.end() ) {
 			LOG(ERROR) << "kernel '" << *it << "' already present in map.";
 			return false;
 		}
 
-		kernel[(*it)] = kern;
-		DLOG(INFO) << "create kernel '"<<(*it).c_str()<<"' from file '" << cl_standard.c_str() << "' for device " << this->name() << " @ " << kernel[(*it)];
+    kernel_map_[(*it)] = kern;
+    DLOG(INFO) << "create kernel '"<<(*it).c_str()<<"' from file '" << cl_standard.c_str() << "' for device " << this->name() << " @ " << kernel_map_[(*it)];
 	}
 
 
@@ -385,18 +384,17 @@ cl_context* OpenCLDevice::getContext() {
 }
 
 cl_command_queue* OpenCLDevice::getQueue() {
-
 	return &queue;
 }
 
 cl_kernel* OpenCLDevice::getKernel(std::string name) {
 
-	if ( kernel.find(name) == kernel.end() ) {
-		LOG(ERROR) << "kernel '" << name << "' not found in map";
+  if (kernel_map_.find(name) == kernel_map_.end()) {
+    LOG(FATAL) << "kernel '" << name << "' not found in map";
 		return NULL;
 	}
 
-	return &kernel[name];
+  return &kernel_map_[name];
 }
 
 bool OpenCLDevice::add(OpenCLMemory& clMem) {

--- a/src/caffe/util/OpenCL/OpenCLDevice.cpp
+++ b/src/caffe/util/OpenCL/OpenCLDevice.cpp
@@ -238,20 +238,6 @@ cl_device_id OpenCLDevice::id() {
 	return deviceID;
 }
 
-//bool OpenCLDevice::createContext() {
-
-//	cl_int err;
-//	cl_context_properties contextProperties[] = { CL_CONTEXT_PLATFORM, (cl_context_properties) platformID, 0 };
-//	context = clCreateContext(contextProperties, 1, &deviceID, NULL, NULL, &err);
-//	if (err != CL_SUCCESS) {
-//		LOG(ERROR)<< "failed to create OpenCL context for device " << this->name();
-//		return false;
-//	}
-//	LOG(INFO)<< "create OpenCL context for platform " << this->name();
-
-//	return true;
-//}
-
 bool OpenCLDevice::compile(std::string cl_source) {
   if (context_() == NULL) {
 		LOG(ERROR)<< "cannot create OpenCL program without OpenCL context";
@@ -334,12 +320,7 @@ bool OpenCLDevice::compile(std::string cl_source) {
 	DLOG(INFO) << "create program from file = '"<< cl_standard.c_str() <<"' for device " << this->name();
 	programs.push_back(program);
 
-
 	std::vector<std::string>::iterator it;
-
-  for( it = kernel_names.begin(); it != kernel_names.end(); it++ ) {
-    std::cout << *it << std::endl;
-  }
 
 	for( it = kernel_names.begin(); it != kernel_names.end(); it++ ) {
 		cl_kernel kern = clCreateKernel(program, (*it).c_str(), &err);

--- a/src/caffe/util/OpenCL/OpenCLManager.cpp
+++ b/src/caffe/util/OpenCL/OpenCLManager.cpp
@@ -21,7 +21,7 @@ bool OpenCLManager::Init() {
     return true;
   }
   LOG(INFO) << "Initialize OpenCL";
-  instance_.LazyQuery();
+  instance_.Query();
   if ( OpenCLManager::GetNumPlatforms() <= 0 ) {
     LOG(FATAL) << "No OpenCL platforms found.";
     return false;
@@ -88,15 +88,6 @@ bool OpenCLManager::Init() {
   return true;
 }
 
-bool OpenCLManager::LazyQuery() {
-  // Query if we haven't already.
-  if (!platforms_.empty()) {
-    return true;
-  } else {
-    return Query();
-  }
-}
-
 bool OpenCLManager::Query() {
   typedef std::vector<cl::Platform> ClPlatforms;
   typedef ClPlatforms::iterator ClPlatformsIter;
@@ -107,7 +98,6 @@ bool OpenCLManager::Query() {
     LOG(INFO) << "found no OpenCL platforms.";
     return false;
   }
-  LOG(INFO) << "found " << platforms_.size() << " OpenCL platforms";
 
   for(ClPlatformsIter it = cl_platforms.begin(); it != cl_platforms.end(); ++it) {
     OpenCLPlatform plat(*it);
@@ -117,6 +107,7 @@ bool OpenCLManager::Query() {
     }
     platforms_.push_back(plat);
   }
+  LOG(INFO) << "found " << platforms_.size() << " OpenCL platforms";
 
   // Temporary hack: platform is the first one.
   current_platform_index_ = 0;
@@ -125,16 +116,14 @@ bool OpenCLManager::Query() {
 }
 
 void OpenCLManager::Print() {
-  PlatformIter it;
 	std::cout << "-- OpenCL Manager Information -----------------------------------" << std::endl;
-  for (it = instance_.platforms_.begin();
+  for (PlatformIter it = instance_.platforms_.begin();
        it != instance_.platforms_.end(); it++) {
     it->print();
 	}
 }
 
 int OpenCLManager::GetNumPlatforms() {
-  instance_.LazyQuery();
   return instance_.platforms_.size();
 }
 

--- a/src/caffe/util/OpenCL/OpenCLManager.cpp
+++ b/src/caffe/util/OpenCL/OpenCLManager.cpp
@@ -7,69 +7,146 @@
 
 namespace caffe {
 
-OpenCLManager::OpenCLManager() {
+OpenCLManager OpenCLManager::instance_;
 
-	numOpenCLPlatforms 	= 0;
-	platformPtr			= NULL;
+OpenCLManager::OpenCLManager() {
 }
 
 OpenCLManager::~OpenCLManager() {
-	free(platformPtr);
 }
 
-bool OpenCLManager::query() {
+bool OpenCLManager::Init() {
+  LOG(INFO) << "Initialize OpenCL";
+  instance_.LazyQuery();
+  if ( OpenCLManager::GetNumPlatforms() <= 0 ) {
+    LOG(FATAL) << "No OpenCL platforms found.";
+    return false;
+  }
 
-	if ( ! CL_CHECK(clGetPlatformIDs(0, NULL, &numOpenCLPlatforms)) ) {
-		return false;
-	}
-	LOG(INFO) << "found " << numOpenCLPlatforms << " OpenCL platforms";
+  // TODO: mechanism for choosing the correct platform.
+  instance_.current_platform_index_ = 0;
 
-	platformPtr = (cl_platform_id*) malloc(numOpenCLPlatforms * sizeof(cl_platform_id));
-	if (platformPtr == NULL) {
-		LOG(ERROR) << "failed to allocate memory";
-		return false;
-	}
+  OpenCLPlatform& pf = CurrentPlatform();
+  pf.print();
 
-	if ( ! CL_CHECK( clGetPlatformIDs(numOpenCLPlatforms, platformPtr, NULL) ) ) {
-		return false;
-	}
+  std::vector<std::string> cl_files;
+  cl_files.push_back("src/caffe/util/OpenCL/math_functions.cl");
+  cl_files.push_back("src/caffe/util/OpenCL/im2col.cl");
+  cl_files.push_back("src/caffe/layers/OpenCL/pooling_layer.cl");
+  cl_files.push_back("src/caffe/layers/OpenCL/relu_layer.cl");
+  cl_files.push_back("src/caffe/layers/OpenCL/prelu_layer.cl");
+  cl_files.push_back("src/caffe/layers/OpenCL/sigmoid_layer.cl");
+  cl_files.push_back("src/caffe/layers/OpenCL/tanh_layer.cl");
+  cl_files.push_back("src/caffe/layers/OpenCL/dropout_layer.cl");
+  cl_files.push_back("src/caffe/layers/OpenCL/bnll_layer.cl");
+  cl_files.push_back("src/caffe/layers/OpenCL/contrastive_loss_layer.cl");
+  cl_files.push_back("src/caffe/layers/OpenCL/eltwise_layer.cl");
+  cl_files.push_back("src/caffe/layers/OpenCL/lrn_layer.cl");
+  cl_files.push_back("src/caffe/layers/OpenCL/softmax_layer.cl");
+  cl_files.push_back("src/caffe/layers/OpenCL/softmax_loss_layer.cl");
+  cl_files.push_back("src/caffe/layers/OpenCL/threshold_layer.cl");
+  cl_files.push_back("src/caffe/layers/OpenCL/mvn_layer.cl");
 
-	for (int i = 0; i < numOpenCLPlatforms; i++) {
+  std::vector<std::string>::iterator it;
 
-		OpenCLPlatform pf = OpenCLPlatform(platformPtr[i]);
-		if ( ! pf.query() ) {
-			LOG(ERROR) << "failed to query platform " << i;
-			return false;
-		}
-		platforms.push_back(pf);
-	}
+  for ( it = cl_files.begin(); it != cl_files.end(); it++ ) {
+    if ( !pf.compile(*it) ) {
+      LOG(ERROR) << "failed to create to create OpenCL program for platform " << pf.name();
+      return false;
+    }
+  }
+
+  if ( pf.getNumGPUDevices() < 1 ) {
+    LOG(ERROR) << "No GPU devices available at platform " << pf.name();
+    return false;
+  }
+
+  pf.SetCurrentDevice(instance_.device_id_);
+  OpenCLDevice& device = pf.CurrentDevice();
+  if (!device.createQueue()) {
+    LOG(ERROR) << "failed to create OpenCL command queue for device "
+               << device.name();
+    return false;
+  }
+
+  if ( clblasSetup() != CL_SUCCESS ) {
+    LOG(ERROR) << "failed to initialize clBlas";
+    return false;
+  }
+
+  device.print();
+  caffe::OpenCL::inititialized = true;
+
+  return true;
+}
+
+bool OpenCLManager::LazyQuery() {
+  // Query if we haven't already.
+  if (!platforms_.empty()) {
+    return true;
+  } else {
+    return Query();
+  }
+}
+
+bool OpenCLManager::Query() {
+  typedef std::vector<cl::Platform> ClPlatforms;
+  typedef ClPlatforms::iterator ClPlatformsIter;
+
+  ClPlatforms cl_platforms;
+  cl::Platform::get(&cl_platforms);
+  if (cl_platforms.empty()) {
+    LOG(INFO) << "found no OpenCL platforms.";
+    return false;
+  }
+  LOG(INFO) << "found " << platforms_.size() << " OpenCL platforms";
+
+  for(ClPlatformsIter it = cl_platforms.begin(); it != cl_platforms.end(); ++it) {
+    OpenCLPlatform plat(*it);
+    if (!plat.Query()) {
+      LOG(ERROR) << "failed to query platform.";
+      return false;
+    }
+    platforms_.push_back(plat);
+  }
+
+  // Temporary hack: platform is the first one.
+  current_platform_index_ = 0;
 
 	return true;
 }
 
-
-
-void OpenCLManager::print() {
-
-	std::vector<caffe::OpenCLPlatform>::iterator it;
+void OpenCLManager::Print() {
+  PlatformIter it;
 	std::cout << "-- OpenCL Manager Information -----------------------------------" << std::endl;
-	for (it = platforms.begin(); it != platforms.end(); it++) {
-		(*it).print();
+  for (it = instance_.platforms_.begin();
+       it != instance_.platforms_.end(); it++) {
+    it->print();
 	}
 }
 
-int OpenCLManager::getNumPlatforms() {
-
-	return numOpenCLPlatforms;
+int OpenCLManager::GetNumPlatforms() {
+  instance_.LazyQuery();
+  return instance_.platforms_.size();
 }
 
 OpenCLPlatform* OpenCLManager::getPlatform(unsigned int idx) {
-
-	if ( idx >= platforms.size() ) {
+  if ( idx >= platforms_.size() ) {
 		LOG(ERROR) << "platform idx = " << idx << " out of range.";
 		return NULL;
 	}
-	return &platforms[idx];
+  return &platforms_[idx];
+}
+
+OpenCLPlatform& OpenCLManager::CurrentPlatform() {
+  if (instance_.current_platform_index_ < 0) {
+    LOG(FATAL) << "No current platform.";
+  }
+  return instance_.platforms_[instance_.current_platform_index_];
+}
+
+void OpenCLManager::SetDeviceId(int device_id) {
+  instance_.device_id_ = device_id;
 }
 
 } // namespace caffe

--- a/src/caffe/util/OpenCL/OpenCLMemory.cpp
+++ b/src/caffe/util/OpenCL/OpenCLMemory.cpp
@@ -38,6 +38,14 @@ OpenCLMemory::OpenCLMemory(size_t size) {
     LOG(FATAL) << oss;
 	}
 
+  cl_uint device_alignment = current_device.getDeviceMemBaseAddrAlign();
+  if (size % device_alignment != 0) {
+    // Requested size does not keep us on device alignment.
+    // Round up to nearest integer multiple of alignment.
+    cl_uint multiple = size / device_alignment + 1;
+    size = multiple * device_alignment;
+  }
+
 	double allocSizeMB = size / (1024.0*1024.0);
 
 	cl_int err;

--- a/src/caffe/util/OpenCL/OpenCLMemory.cpp
+++ b/src/caffe/util/OpenCL/OpenCLMemory.cpp
@@ -38,14 +38,6 @@ OpenCLMemory::OpenCLMemory(size_t size) {
     LOG(FATAL) << oss;
 	}
 
-  cl_uint device_alignment = current_device.getDeviceMemBaseAddrAlign();
-  if (size % device_alignment != 0) {
-    // Requested size does not keep us on device alignment.
-    // Round up to nearest integer multiple of alignment.
-    cl_uint multiple = size / device_alignment + 1;
-    size = multiple * device_alignment;
-  }
-
 	double allocSizeMB = size / (1024.0*1024.0);
 
 	cl_int err;

--- a/src/caffe/util/OpenCL/OpenCLMemory.cpp
+++ b/src/caffe/util/OpenCL/OpenCLMemory.cpp
@@ -30,8 +30,8 @@ OpenCLMemory::OpenCLMemory() {
 
 OpenCLMemory::OpenCLMemory(size_t size) {
   OpenCLDevice& current_device = OpenCLManager::CurrentPlatform().CurrentDevice();
-  cl_context* context = current_device.getContext();
-	if ( ! context ) {
+  cl_context context = current_device.getContext();
+  if ( ! context ) {
 		std::ostringstream oss;
     oss << current_device.name() << "> failed to get OpenCL context.";
     //throw OpenCLMemoryException(oss.str());
@@ -41,7 +41,7 @@ OpenCLMemory::OpenCLMemory(size_t size) {
 	double allocSizeMB = size / (1024.0*1024.0);
 
 	cl_int err;
-	this->ptr_device_mem_ = clCreateBuffer(*context, CL_MEM_READ_WRITE, size, NULL, &err);
+  this->ptr_device_mem_ = clCreateBuffer(context, CL_MEM_READ_WRITE, size, NULL, &err);
 	if ( err != CL_SUCCESS ) {
 		std::ostringstream oss;
     oss << current_device.name() << "> failed to create CL_MEM_READ_WRITE buffer of "<<allocSizeMB<<" MByte";
@@ -70,7 +70,6 @@ OpenCLMemory::OpenCLMemory(size_t size) {
 	numCallsMalloc++;
 	statictics();
 }
-
 
 OpenCLMemory::OpenCLMemory(const OpenCLMemory& mem) {
 

--- a/src/caffe/util/OpenCL/OpenCLPlatform.cpp
+++ b/src/caffe/util/OpenCL/OpenCLPlatform.cpp
@@ -22,16 +22,16 @@ OpenCLPlatform::OpenCLPlatform():
 	cpuDevicePtr 		= NULL;
 	gpuDevicePtr 		= NULL;
 	devicePtr	 		= NULL;
-	context				= NULL;
 }
 
 OpenCLPlatform::OpenCLPlatform(const OpenCLPlatform& pf):
+  platform_(pf.platform_),
   name_(pf.name_),
   vendor_(pf.vendor_),
   version_(pf.version_),
   extensions_(pf.extensions_),
   profile_(pf.profile_),
-  current_device_index_(-1) {
+  current_device_index_(pf.current_device_index_) {
   numCPUDevices 		= pf.numCPUDevices;
 	numGPUDevices 		= pf.numGPUDevices;
 	numDevices	  		= pf.numDevices;
@@ -39,8 +39,8 @@ OpenCLPlatform::OpenCLPlatform(const OpenCLPlatform& pf):
 	gpuDevicePtr 		= pf.gpuDevicePtr;
 	devicePtr	 		= pf.devicePtr;
 	devices				= pf.devices;
-	context				= pf.context;
-	programs			= pf.programs;
+  context_				= pf.context_;
+//	programs			= pf.programs;
 }
 
 OpenCLPlatform::OpenCLPlatform(cl::Platform platform):
@@ -52,22 +52,21 @@ OpenCLPlatform::OpenCLPlatform(cl::Platform platform):
 	cpuDevicePtr 		= NULL;
 	gpuDevicePtr 		= NULL;
 	devicePtr	 		= NULL;
-	context 			= NULL;
 }
 
 OpenCLPlatform::~OpenCLPlatform() {
-	if ( context != NULL ) {
-		clReleaseContext(context);
-		LOG(INFO) << "release OpenCL context on platform " << name();
-	}
+//	if ( context != NULL ) {
+//		clReleaseContext(context);
+//		LOG(INFO) << "release OpenCL context on platform " << name();
+//	}
 
-	std::vector<cl_program>::iterator it;
-	for ( it = programs.begin(); it != programs.end(); it++ ) {
-		if ( (*it) != NULL ) {
-			//clReleaseProgram((*it));
-			//LOG(INFO) << "release OpenCL program on platform " << name();
-		}
-	}
+//	std::vector<cl_program>::iterator it;
+//	for ( it = programs.begin(); it != programs.end(); it++ ) {
+//		if ( (*it) != NULL ) {
+//			//clReleaseProgram((*it));
+//			//LOG(INFO) << "release OpenCL program on platform " << name();
+//		}
+//	}
 }
 
 // Check that we have an assigned cl::Platform object.
@@ -123,7 +122,7 @@ bool OpenCLPlatform::Query() {
 		}
 
 		for (int i = 0; i < numCPUDevices; i++) {
-      OpenCLDevice d = OpenCLDevice(platform_(), cpuDevicePtr[i]);
+      OpenCLDevice d(platform_(), cpuDevicePtr[i]);
 			d.query();
 			devices.push_back(d);
 		}
@@ -139,7 +138,7 @@ bool OpenCLPlatform::Query() {
 	}
 
 	for (int i = 0; i < numGPUDevices; i++) {
-    OpenCLDevice d = OpenCLDevice(platform_(), gpuDevicePtr[i]);
+    OpenCLDevice d(platform_(), gpuDevicePtr[i]);
 		d.query();
 		devices.push_back(d);
 	}
@@ -249,7 +248,9 @@ cl_platform_id OpenCLPlatform::id() {
 bool OpenCLPlatform::createContext() {
 	cl_int err;
   cl_context_properties contextProperties[] = { CL_CONTEXT_PLATFORM, (cl_context_properties) platform_(), 0};
-	context = clCreateContext(contextProperties, numDevices, devicePtr, NULL, NULL, &err);
+//	cl_context context = clCreateContext(contextProperties, numDevices, devicePtr, NULL, NULL, &err);
+  context_ = cl::Context(CL_DEVICE_TYPE_CPU | CL_DEVICE_TYPE_GPU,
+                         contextProperties, NULL, NULL, &err);
 	if ( err != CL_SUCCESS ) {
 		LOG(ERROR) << "failed to create context.";
 		return false;
@@ -258,97 +259,98 @@ bool OpenCLPlatform::createContext() {
 
 	std::vector<caffe::OpenCLDevice>::iterator it;
 	for (it = devices.begin(); it != devices.end(); it++) {
-		if ( ! (*it).createContext() ) {
-			return false;
-		}
+//		if ( ! (*it).createContext() ) {
+//			return false;
+      it->SetContext(context_);
+//		}
 	}
 
 	return true;
 }
 
 bool OpenCLPlatform::compile(std::string cl_source) {
-	if ( context == NULL ) {
-		LOG(ERROR) << "cannot create OpenCL program without OpenCL context";
-		return false;
-	}
+//  if ( context_() == NULL ) {
+//		LOG(ERROR) << "cannot create OpenCL program without OpenCL context";
+//		return false;
+//	}
 
-	if ( access( cl_source.c_str(), F_OK ) == -1 ) {
-		LOG(ERROR) << "kernel source file = '" << cl_source.c_str() << "' doesn't exist";
-		return false;
-	}
+//	if ( access( cl_source.c_str(), F_OK ) == -1 ) {
+//		LOG(ERROR) << "kernel source file = '" << cl_source.c_str() << "' doesn't exist";
+//		return false;
+//	}
 
-	if ( access( cl_source.c_str(), R_OK ) == -1 ) {
-		LOG(ERROR) << "kernel source file = '" << cl_source.c_str() << "' isn't readable";
-		return false;
-	}
+//	if ( access( cl_source.c_str(), R_OK ) == -1 ) {
+//		LOG(ERROR) << "kernel source file = '" << cl_source.c_str() << "' isn't readable";
+//		return false;
+//	}
 
-	caffe::OpenCLParser parser;
+//	caffe::OpenCLParser parser;
 
-	boost::regex re("\\.cl", boost::regex::perl);
-	std::string cl_standard = boost::regex_replace(cl_source, re, "-STD.cl");
+//	boost::regex re("\\.cl", boost::regex::perl);
+//	std::string cl_standard = boost::regex_replace(cl_source, re, "-STD.cl");
 
-	if ( ! parser.convert(cl_source, cl_standard) ) {
-		LOG(ERROR) << "failed to convert kernel source file = '" << cl_source.c_str() << "' to standard OpenCL";
-		return false;
-	}
+//	if ( ! parser.convert(cl_source, cl_standard) ) {
+//		LOG(ERROR) << "failed to convert kernel source file = '" << cl_source.c_str() << "' to standard OpenCL";
+//		return false;
+//	}
 
-	std::vector<std::string> kernel_names;
-	if ( ! parser.getKernelNames(cl_standard, kernel_names) ) {
-		LOG(ERROR) << "failed to parse kernel names from file '"<<cl_standard.c_str()<<"'";
-		return false;
-	}
+//	std::vector<std::string> kernel_names;
+//	if ( ! parser.getKernelNames(cl_standard, kernel_names) ) {
+//		LOG(ERROR) << "failed to parse kernel names from file '"<<cl_standard.c_str()<<"'";
+//		return false;
+//	}
 
-	std::string str(std::istreambuf_iterator<char>(std::ifstream(cl_standard.c_str()).rdbuf()), std::istreambuf_iterator<char>());
-	if ( str.size() <= 0 ) {
-		LOG(ERROR) << "failed to read data from file = '"<< cl_standard.c_str() <<"'";
-		return false;
-	}
+//	std::string str(std::istreambuf_iterator<char>(std::ifstream(cl_standard.c_str()).rdbuf()), std::istreambuf_iterator<char>());
+//	if ( str.size() <= 0 ) {
+//		LOG(ERROR) << "failed to read data from file = '"<< cl_standard.c_str() <<"'";
+//		return false;
+//	}
 
-	cl_int err;
-	const char *list = str.c_str();
-	size_t sourceSize[] = {strlen(str.c_str())};
-	cl_program program = clCreateProgramWithSource(context, 1, &list, sourceSize, &err);
-	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "failed to create program from file = '"<< cl_standard.c_str() <<"'";
-		return false;
-	}
-	DLOG(INFO) << "create program with source from file = '"<< cl_standard.c_str() <<"' for platform " << this->name();
+//	cl_int err;
+//	const char *list = str.c_str();
+//	size_t sourceSize[] = {strlen(str.c_str())};
+//  cl_program program = clCreateProgramWithSource(context_(), 1, &list, sourceSize, &err);
+//	if ( err != CL_SUCCESS ) {
+//		LOG(ERROR) << "failed to create program from file = '"<< cl_standard.c_str() <<"'";
+//		return false;
+//	}
+//	DLOG(INFO) << "create program with source from file = '"<< cl_standard.c_str() <<"' for platform " << this->name();
 
-	//-x clc++ -O5
-	std::string clIncludes = std::string("-cl-unsafe-math-optimizations -cl-finite-math-only -cl-fast-relaxed-math -cl-single-precision-constant -cl-denorms-are-zero -cl-mad-enable -cl-no-signed-zeros -I ../../CL/include/");
-	err = clBuildProgram(program, numDevices, devicePtr, clIncludes.c_str(), NULL, NULL);
-	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "failed to build OpenCL program from file '" << cl_standard.c_str() << "' : error = " << err;
+//	//-x clc++ -O5
+//	std::string clIncludes = std::string("-cl-unsafe-math-optimizations -cl-finite-math-only -cl-fast-relaxed-math -cl-single-precision-constant -cl-denorms-are-zero -cl-mad-enable -cl-no-signed-zeros -I ../../CL/include/");
+//	err = clBuildProgram(program, numDevices, devicePtr, clIncludes.c_str(), NULL, NULL);
+//	if ( err != CL_SUCCESS ) {
+//		LOG(ERROR) << "failed to build OpenCL program from file '" << cl_standard.c_str() << "' : error = " << err;
 
-		char* logBuffer = (char*) malloc(1024 * 1024);
-		size_t tempSize;
+//		char* logBuffer = (char*) malloc(1024 * 1024);
+//		size_t tempSize;
 
-		std::vector<caffe::OpenCLDevice>::iterator it;
-		for (it = devices.begin(); it != devices.end(); it++) {
-			err = clGetProgramBuildInfo(program, (*it).id(), CL_PROGRAM_BUILD_LOG, 1000000, logBuffer, &tempSize);
-			if ( err != CL_SUCCESS ) {
-				LOG(ERROR) << "clGetProgramBuildInfo() failed.";
-				return false;
-			}
-			LOG(ERROR) << (*it).name() << "> build log size is " << tempSize;
-			LOG(ERROR) << logBuffer;
+//		std::vector<caffe::OpenCLDevice>::iterator it;
+//		for (it = devices.begin(); it != devices.end(); it++) {
+//			err = clGetProgramBuildInfo(program, (*it).id(), CL_PROGRAM_BUILD_LOG, 1000000, logBuffer, &tempSize);
+//			if ( err != CL_SUCCESS ) {
+//				LOG(ERROR) << "clGetProgramBuildInfo() failed.";
+//				return false;
+//			}
+//			LOG(ERROR) << (*it).name() << "> build log size is " << tempSize;
+//			LOG(ERROR) << logBuffer;
 
-			std::ostringstream os;
-			os<<"CLBuildLog_"<<(*it).name().c_str()<<".log";
+//			std::ostringstream os;
+//			os<<"CLBuildLog_"<<(*it).name().c_str()<<".log";
 
-			FILE* tempLogFile = fopen(os.str().c_str(), "w");
-			if ( tempLogFile == NULL ) {
-				LOG(ERROR) << "failed to open build log file '" << os.str().c_str() << "'";
-			} else {
-				fwrite(logBuffer, 1, tempSize, tempLogFile);
-				fclose(tempLogFile);
-				DLOG(INFO) << "OpenCL build log written to file '" << os.str().c_str() << "'";
-			}
-		}
-		return false;
-	}
-	DLOG(INFO) << "create program for all devices from file = '"<< cl_standard.c_str() <<"' for platform " << this->name();
-	programs.push_back(program);
+//			FILE* tempLogFile = fopen(os.str().c_str(), "w");
+//			if ( tempLogFile == NULL ) {
+//				LOG(ERROR) << "failed to open build log file '" << os.str().c_str() << "'";
+//			} else {
+//				fwrite(logBuffer, 1, tempSize, tempLogFile);
+//				fclose(tempLogFile);
+//				DLOG(INFO) << "OpenCL build log written to file '" << os.str().c_str() << "'";
+//			}
+//		}
+//		return false;
+//	}
+//	DLOG(INFO) << "create program for all devices from file = '"<< cl_standard.c_str() <<"' for platform " << this->name();
+//	programs.push_back(program);
 
 	std::vector<caffe::OpenCLDevice>::iterator it;
 	for (it = devices.begin(); it != devices.end(); it++) {

--- a/src/caffe/util/OpenCL/OpenCLPlatform.cpp
+++ b/src/caffe/util/OpenCL/OpenCLPlatform.cpp
@@ -248,7 +248,6 @@ cl_platform_id OpenCLPlatform::id() {
 bool OpenCLPlatform::createContext() {
 	cl_int err;
   cl_context_properties contextProperties[] = { CL_CONTEXT_PLATFORM, (cl_context_properties) platform_(), 0};
-//	cl_context context = clCreateContext(contextProperties, numDevices, devicePtr, NULL, NULL, &err);
   context_ = cl::Context(CL_DEVICE_TYPE_CPU | CL_DEVICE_TYPE_GPU,
                          contextProperties, NULL, NULL, &err);
 	if ( err != CL_SUCCESS ) {
@@ -259,106 +258,19 @@ bool OpenCLPlatform::createContext() {
 
 	std::vector<caffe::OpenCLDevice>::iterator it;
 	for (it = devices.begin(); it != devices.end(); it++) {
-//		if ( ! (*it).createContext() ) {
-//			return false;
       it->SetContext(context_);
-//		}
 	}
 
 	return true;
 }
 
 bool OpenCLPlatform::compile(std::string cl_source) {
-//  if ( context_() == NULL ) {
-//		LOG(ERROR) << "cannot create OpenCL program without OpenCL context";
-//		return false;
-//	}
-
-//	if ( access( cl_source.c_str(), F_OK ) == -1 ) {
-//		LOG(ERROR) << "kernel source file = '" << cl_source.c_str() << "' doesn't exist";
-//		return false;
-//	}
-
-//	if ( access( cl_source.c_str(), R_OK ) == -1 ) {
-//		LOG(ERROR) << "kernel source file = '" << cl_source.c_str() << "' isn't readable";
-//		return false;
-//	}
-
-//	caffe::OpenCLParser parser;
-
-//	boost::regex re("\\.cl", boost::regex::perl);
-//	std::string cl_standard = boost::regex_replace(cl_source, re, "-STD.cl");
-
-//	if ( ! parser.convert(cl_source, cl_standard) ) {
-//		LOG(ERROR) << "failed to convert kernel source file = '" << cl_source.c_str() << "' to standard OpenCL";
-//		return false;
-//	}
-
-//	std::vector<std::string> kernel_names;
-//	if ( ! parser.getKernelNames(cl_standard, kernel_names) ) {
-//		LOG(ERROR) << "failed to parse kernel names from file '"<<cl_standard.c_str()<<"'";
-//		return false;
-//	}
-
-//	std::string str(std::istreambuf_iterator<char>(std::ifstream(cl_standard.c_str()).rdbuf()), std::istreambuf_iterator<char>());
-//	if ( str.size() <= 0 ) {
-//		LOG(ERROR) << "failed to read data from file = '"<< cl_standard.c_str() <<"'";
-//		return false;
-//	}
-
-//	cl_int err;
-//	const char *list = str.c_str();
-//	size_t sourceSize[] = {strlen(str.c_str())};
-//  cl_program program = clCreateProgramWithSource(context_(), 1, &list, sourceSize, &err);
-//	if ( err != CL_SUCCESS ) {
-//		LOG(ERROR) << "failed to create program from file = '"<< cl_standard.c_str() <<"'";
-//		return false;
-//	}
-//	DLOG(INFO) << "create program with source from file = '"<< cl_standard.c_str() <<"' for platform " << this->name();
-
-//	//-x clc++ -O5
-//	std::string clIncludes = std::string("-cl-unsafe-math-optimizations -cl-finite-math-only -cl-fast-relaxed-math -cl-single-precision-constant -cl-denorms-are-zero -cl-mad-enable -cl-no-signed-zeros -I ../../CL/include/");
-//	err = clBuildProgram(program, numDevices, devicePtr, clIncludes.c_str(), NULL, NULL);
-//	if ( err != CL_SUCCESS ) {
-//		LOG(ERROR) << "failed to build OpenCL program from file '" << cl_standard.c_str() << "' : error = " << err;
-
-//		char* logBuffer = (char*) malloc(1024 * 1024);
-//		size_t tempSize;
-
-//		std::vector<caffe::OpenCLDevice>::iterator it;
-//		for (it = devices.begin(); it != devices.end(); it++) {
-//			err = clGetProgramBuildInfo(program, (*it).id(), CL_PROGRAM_BUILD_LOG, 1000000, logBuffer, &tempSize);
-//			if ( err != CL_SUCCESS ) {
-//				LOG(ERROR) << "clGetProgramBuildInfo() failed.";
-//				return false;
-//			}
-//			LOG(ERROR) << (*it).name() << "> build log size is " << tempSize;
-//			LOG(ERROR) << logBuffer;
-
-//			std::ostringstream os;
-//			os<<"CLBuildLog_"<<(*it).name().c_str()<<".log";
-
-//			FILE* tempLogFile = fopen(os.str().c_str(), "w");
-//			if ( tempLogFile == NULL ) {
-//				LOG(ERROR) << "failed to open build log file '" << os.str().c_str() << "'";
-//			} else {
-//				fwrite(logBuffer, 1, tempSize, tempLogFile);
-//				fclose(tempLogFile);
-//				DLOG(INFO) << "OpenCL build log written to file '" << os.str().c_str() << "'";
-//			}
-//		}
-//		return false;
-//	}
-//	DLOG(INFO) << "create program for all devices from file = '"<< cl_standard.c_str() <<"' for platform " << this->name();
-//	programs.push_back(program);
-
 	std::vector<caffe::OpenCLDevice>::iterator it;
 	for (it = devices.begin(); it != devices.end(); it++) {
 		if ( ! (*it).compile(cl_source) ) {
 			return false;
 		}
 	}
-
 	return true;
 }
 
@@ -366,12 +278,6 @@ OpenCLDevice& OpenCLPlatform::CurrentDevice() {
   if (current_device_index_ < 0 ) {
     LOG(FATAL) << "Current device not set.";
   }
-//  OpenCLDevice& device = pf.getDevice(CL_DEVICE_TYPE_GPU, 0);
-//  if (!gpu) {
-//    LOG(ERROR) << "failed to select first GPU on platform " << pf.name();
-//		return false;
-//	}
-
   return devices[current_device_index_];
 }
 

--- a/src/caffe/util/OpenCL/OpenCLPlatform.cpp
+++ b/src/caffe/util/OpenCL/OpenCLPlatform.cpp
@@ -81,36 +81,44 @@ bool OpenCLPlatform::Query() {
   Check();
 
 	// get the name
-  cl_int err;
+  cl_int err = 0;
   name_ = platform_.getInfo<CL_PLATFORM_NAME>(&err);
-  if (!CL_CHECK(err)) return false;
+  if (!CL_CHECK(err)) { name_ = "Failed to get platform name."; }
 
 	// get the vendor
   vendor_ = platform_.getInfo<CL_PLATFORM_VENDOR>(&err);
-  if (!CL_CHECK(err)) return false;
+  if (!CL_CHECK(err)) { vendor_ = "Failed to get platform vendor."; }
 
   version_ = platform_.getInfo<CL_PLATFORM_VERSION>(&err);
-  if (!CL_CHECK(err)) return false;
+  if (!err) { version_ = "Failed to get platform version."; }
 
   extensions_ = platform_.getInfo<CL_PLATFORM_EXTENSIONS>(&err);
-  if (!CL_CHECK(err)) return false;
+  if (!CL_CHECK(err)) { extensions_ = "failed to get platform extensions."; }
 
   profile_ = platform_.getInfo<CL_PLATFORM_PROFILE>(&err);
-  if (!CL_CHECK(err)) return false;
+  if (!CL_CHECK(err)) { profile_ = "Failed to get platform profile."; }
 
 	// CPU & GPU devices
-  if (!CL_CHECK( clGetDeviceIDs(platform_(), CL_DEVICE_TYPE_CPU | CL_DEVICE_TYPE_GPU, 0, NULL, &(numDevices)) ) ) {
+  if (!CL_CHECK( clGetDeviceIDs(platform_(),
+                                CL_DEVICE_TYPE_CPU | CL_DEVICE_TYPE_GPU,
+                                0, NULL, &(numDevices)) ) ) {
 		return false;
 	}
 	devicePtr = (cl_device_id*) malloc(numDevices * sizeof(cl_device_id));
-  if (!CL_CHECK( clGetDeviceIDs(platform_(), CL_DEVICE_TYPE_CPU | CL_DEVICE_TYPE_GPU, numDevices, devicePtr, NULL) ) ) {
+  if (!CL_CHECK( clGetDeviceIDs(platform_(),
+                                CL_DEVICE_TYPE_CPU | CL_DEVICE_TYPE_GPU,
+                                numDevices, devicePtr, NULL) ) ) {
 		return false;
 	}
 
 	// CPU devices
-  if ( clGetDeviceIDs(platform_(), CL_DEVICE_TYPE_CPU, 0, NULL, &(numCPUDevices)) == CL_SUCCESS ) {
-		cpuDevicePtr = (cl_device_id*) malloc(numCPUDevices * sizeof(cl_device_id));
-    if ( ! CL_CHECK( clGetDeviceIDs(platform_(), CL_DEVICE_TYPE_CPU, numCPUDevices, cpuDevicePtr, NULL) ) ) {
+  if ( clGetDeviceIDs(platform_(), CL_DEVICE_TYPE_CPU, 0,
+                      NULL, &(numCPUDevices)) == CL_SUCCESS ) {
+    cpuDevicePtr =
+        (cl_device_id*) malloc(numCPUDevices * sizeof(cl_device_id));
+    if ( ! CL_CHECK( clGetDeviceIDs(platform_(),
+                     CL_DEVICE_TYPE_CPU,
+                     numCPUDevices, cpuDevicePtr, NULL) ) ) {
 			return false;
 		}
 

--- a/src/caffe/util/OpenCL/OpenCLPlatform.cpp
+++ b/src/caffe/util/OpenCL/OpenCLPlatform.cpp
@@ -281,6 +281,10 @@ OpenCLDevice& OpenCLPlatform::CurrentDevice() {
   return devices[current_device_index_];
 }
 
+void OpenCLPlatform::DeviceSynchronize() {
+  CurrentDevice().Synchronize();
+}
+
 void OpenCLPlatform::SetCurrentDevice(int device_index) {
   if (device_index >= numCPUDevices + numGPUDevices ||
       device_index < 0) {
@@ -288,7 +292,6 @@ void OpenCLPlatform::SetCurrentDevice(int device_index) {
   }
   current_device_index_ = device_index;
 }
-
 
 } // namespace caffe
 

--- a/src/caffe/util/OpenCL/OpenCLSupport.cpp
+++ b/src/caffe/util/OpenCL/OpenCLSupport.cpp
@@ -773,7 +773,7 @@ bool clSetKernelArrayArg(const void* ptr_virtual, unsigned int& idx,
 	/* check alignment */
   cl_uint bytes = device.getDeviceMemBaseAddrAlign();
 	if ( offset % bytes != 0 ) {
-		LOG(WARNING)<<"sub-buffer memory offset ("<<offset<<" Byte) is not aligned with device memory offset ("<<bytes<<" Byte)";
+    //LOG(WARNING)<<"sub-buffer memory offset ("<<offset<<" Byte) is not aligned with device memory offset ("<<bytes<<" Byte)";
 
 		cl_mem_flags flags;
 		err = clGetMemObjectInfo((cl_mem) ptr_logical, CL_MEM_FLAGS, sizeof(flags), &flags, NULL);
@@ -1534,6 +1534,14 @@ bool clBLASgemm(const clblasTranspose TransA, const clblasTranspose TransB, cons
       LOG(ERROR) << "clblasSgemm() failed on GPU "<<device.name();
 			//clReleaseSubBuffers(sb);
 			//clReleaseBufferMap(bm);
+
+      std::cout << "clblasRowMajor " << std::endl
+                << "TransA: " << TransA << std::endl
+                << "TransB: " << TransB << std::endl
+                << "m: " << m << std::endl
+                << "n: " << n << std::endl
+                << "k:" << k << std::endl
+                << "beta: " << beta << std::endl;
 			return false;
 		}
 		////clFinish(*queue);

--- a/src/caffe/util/OpenCL/OpenCLSupport.cpp
+++ b/src/caffe/util/OpenCL/OpenCLSupport.cpp
@@ -773,7 +773,7 @@ bool clSetKernelArrayArg(const void* ptr_virtual, unsigned int& idx,
 	/* check alignment */
   cl_uint bytes = device.getDeviceMemBaseAddrAlign();
 	if ( offset % bytes != 0 ) {
-    //LOG(WARNING)<<"sub-buffer memory offset ("<<offset<<" Byte) is not aligned with device memory offset ("<<bytes<<" Byte)";
+    LOG(WARNING)<<"sub-buffer memory offset ("<<offset<<" Byte) is not aligned with device memory offset ("<<bytes<<" Byte)";
 
 		cl_mem_flags flags;
 		err = clGetMemObjectInfo((cl_mem) ptr_logical, CL_MEM_FLAGS, sizeof(flags), &flags, NULL);

--- a/src/caffe/util/OpenCL/OpenCLSupport.cpp
+++ b/src/caffe/util/OpenCL/OpenCLSupport.cpp
@@ -15,12 +15,11 @@ namespace caffe {
 namespace OpenCL {
 
 bool inititialized = false;
-caffe::OpenCLManager mgr = OpenCLManager();
-caffe::OpenCLPlatform* pf;
-caffe::OpenCLDevice* gpu;
-cl_context*	context;
-cl_command_queue* queue;
-cl_kernel* kernel;
+//caffe::OpenCLPlatform* pf;
+//caffe::OpenCLDevice* gpu;
+//cl_context*	context;
+//cl_command_queue* queue;
+//cl_kernel* kernel;
 
 const char* what(cl_int value) {
 	int errorCode = (int) value;
@@ -239,92 +238,6 @@ double getTickFrequency() {
 	return (double) t.tv_nsec;
 }
 
-bool init() {
-
-	if ( caffe::OpenCL::inititialized ) {
-		LOG(INFO)<<"OpenCL already initialized";
-		return true;
-	}
-
-	LOG(INFO)<<"Initialize OpenCL";
-	mgr.query();
-
-	if ( ! mgr.query() ) {
-		LOG(ERROR) << "Failed to query OpenCL runtime information";
-		return false;
-	}
-
-	if ( mgr.getNumPlatforms() <= 0 ) {
-		LOG(ERROR) << "No OpenCL platforms found.";
-		return false;
-	}
-
-	pf = mgr.getPlatform(0);
-	if ( ! pf ) {
-		LOG(ERROR) << "Failed to get first platform.";
-		return false;
-	}
-
-	if ( ! pf->createContext() ) {
-		LOG(ERROR) << "failed to create OpenCL context for platform " << pf->name();
-		return false;
-	}
-
-	std::vector<std::string> cl_files;
-	cl_files.push_back("src/caffe/util/OpenCL/math_functions.cl");
-	cl_files.push_back("src/caffe/util/OpenCL/im2col.cl");
-	cl_files.push_back("src/caffe/layers/OpenCL/pooling_layer.cl");
-	cl_files.push_back("src/caffe/layers/OpenCL/relu_layer.cl");
-	cl_files.push_back("src/caffe/layers/OpenCL/prelu_layer.cl");
-	cl_files.push_back("src/caffe/layers/OpenCL/sigmoid_layer.cl");
-	cl_files.push_back("src/caffe/layers/OpenCL/tanh_layer.cl");
-	cl_files.push_back("src/caffe/layers/OpenCL/dropout_layer.cl");
-	cl_files.push_back("src/caffe/layers/OpenCL/bnll_layer.cl");
-	cl_files.push_back("src/caffe/layers/OpenCL/contrastive_loss_layer.cl");
-	cl_files.push_back("src/caffe/layers/OpenCL/eltwise_layer.cl");
-	cl_files.push_back("src/caffe/layers/OpenCL/lrn_layer.cl");
-	cl_files.push_back("src/caffe/layers/OpenCL/softmax_layer.cl");
-	cl_files.push_back("src/caffe/layers/OpenCL/softmax_loss_layer.cl");
-	cl_files.push_back("src/caffe/layers/OpenCL/threshold_layer.cl");
-	cl_files.push_back("src/caffe/layers/OpenCL/mvn_layer.cl");
-
-	std::vector<std::string>::iterator it;
-
-	for ( it = cl_files.begin(); it != cl_files.end(); it++ ) {
-		if ( ! pf->compile(*it) ) {
-			LOG(ERROR) << "failed to create to create OpenCL program for platform " << pf->name();
-			return false;
-		}
-	}
-
-	if ( pf->getNumGPUDevices() < 1 ) {
-		LOG(ERROR) << "No GPU devices available at platform " << pf->name();
-		return false;
-	}
-
-	gpu = pf->getDevice(CL_DEVICE_TYPE_GPU, 0);
-	if ( ! gpu ) {
-		LOG(ERROR) << "failed to select first GPU on platform " << pf->name();
-		return false;
-	}
-
-	if ( ! gpu->createQueue() ) {
-		LOG(ERROR) << "failed to create OpenCL command queue for device " << gpu->name();
-		return false;
-	}
-
-
-	if ( clblasSetup() != CL_SUCCESS ) {
-		LOG(ERROR) << "failed to initialize clBlas";
-		return false;
-	}
-
-	gpu->print();
-	caffe::OpenCL::inititialized = true;
-
-	return true;
-}
-
 template<typename T>
 std::string clGetKernelName(std::string name) {
 
@@ -350,6 +263,8 @@ template std::string clGetKernelName<double>(std::string name);
 template std::string clGetKernelName<float>(std::string name);
 
 bool clMalloc(void** virtualPtr, size_t size) {
+  OpenCLPlatform& pf = OpenCLManager::CurrentPlatform();
+  OpenCLDevice& device = pf.CurrentDevice();
 
 	OpenCLMemory clMem;
 	try {
@@ -357,28 +272,30 @@ bool clMalloc(void** virtualPtr, size_t size) {
 	} catch (std::exception& e) {
 		return false;
 	}
-	gpu->add(clMem);
+  device.add(clMem);
 
 	*virtualPtr = clMem.getVirtualPointer();
 	return true;
 }
 
 bool clFree(void* virtualPtr) {
+  OpenCLPlatform& pf = OpenCLManager::CurrentPlatform();
+  OpenCLDevice& device = pf.CurrentDevice();
 
-	if ( ! gpu->isValidPtr(virtualPtr) ) {
-		LOG(ERROR) << gpu->name() << "> not a valid memory pointer @ " << virtualPtr;
+  if (!device.isValidPtr(virtualPtr)) {
+    LOG(ERROR) << device.name() << "> not a valid memory pointer @ " << virtualPtr;
 		return false;
 	}
 
 	OpenCLMemory clMem;
-	if ( ! gpu->get(virtualPtr, clMem) ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCLMemory object using virtual pointer @ " << virtualPtr;
+  if (!device.get(virtualPtr, clMem)) {
+    LOG(ERROR) << device.name() << "> failed to get OpenCLMemory object using virtual pointer @ " << virtualPtr;
 		return false;
 	}
 
-	gpu->rmMemoryPtr(clMem.getVirtualPointer());
-	queue = gpu->getQueue();
-	if ( queue != NULL ) {
+  device.rmMemoryPtr(clMem.getVirtualPointer());
+  cl_command_queue* queue = device.getQueue();
+  if (queue!=NULL)  {
 		clFinish(*queue);
 	}
 	return true;
@@ -386,32 +303,38 @@ bool clFree(void* virtualPtr) {
 
 template<typename T>
 bool clMemset(void* virtualPtr, const T alpha, const size_t Bytes) {
-
-	queue = gpu->getQueue();
-	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+  OpenCLPlatform& pf = OpenCLManager::CurrentPlatform();
+  OpenCLDevice& device = pf.CurrentDevice();
+  cl_command_queue* queue = device.getQueue();
+  if (!queue) {
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
 #ifdef OPENCL_VERSION_1_2 // at least OpenCL Version 1.2 required
 
-	if ( ! gpu->isValidPtr(virtualPtr) ) {
-		LOG(ERROR) << gpu->name() << "> not a valid memory pointer @ " << virtualPtr;
+  if (!device.isValidPtr(virtualPtr)) {
+    LOG(ERROR) << device.name()
+               << "> not a valid memory pointer @ "
+               << virtualPtr;
 		return false;
 	}
 
 	OpenCLMemory clMem;
-	if ( ! gpu->get(virtualPtr, clMem) ) {
-		LOG(ERROR) << gpu->name() << "> failed to get GPU memory @ " << virtualPtr;
+  if (!device.get(virtualPtr, clMem)) {
+    LOG(ERROR) << device.name() << "> failed to get GPU memory @ "
+               << virtualPtr;
 		return false;
 	}
 	size_t mem_offset	= clGetMemoryOffset(virtualPtr);
 	cl_mem base 			= (cl_mem) clMem.getLogicalPointer();
 
-	cl_int err = clEnqueueFillBuffer(*queue, base, &alpha, sizeof(T), mem_offset, Bytes, 0, NULL, NULL);
-	if ( err != CL_SUCCESS ) {
+  cl_int err = clEnqueueFillBuffer(*queue, base, &alpha, sizeof(T),
+                                   mem_offset, Bytes, 0, NULL, NULL);
+  if (err != CL_SUCCESS) {
     std::ostringstream oss;
-    oss << "clEnqueueFillBuffer() failed on GPU "<<gpu->name()<<" : "<<what(err);
+    oss << "clEnqueueFillBuffer() failed on GPU " << device.name()
+        << " : "<<what(err);
     //LOG(ERROR)<<oss.str();
     throw OpenCLSupportException(oss.str());
 		return false;
@@ -421,7 +344,7 @@ bool clMemset(void* virtualPtr, const T alpha, const size_t Bytes) {
 #else
 	std::string kernel_name = clGetKernelName<T>("clFillBuffer");
 
-	kernel = gpu->getKernel(kernel_name);
+  kernel = device.getKernel(kernel_name);
 	if ( kernel == NULL ) {
 		return false;
 	}
@@ -435,92 +358,100 @@ bool clMemset(void* virtualPtr, const T alpha, const size_t Bytes) {
 	size_t global = CAFFE_GET_GLOBAL_WORKITEMS(N, OPENCL_LOCAL_SIZE);
 	size_t local  = CAFFE_GET_LOCAL_WORKITEMS(N, OPENCL_LOCAL_SIZE);
 
-	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
+  err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL,
+                               &global, &local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
 		std::ostringstream oss;
-		oss << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<what(err);
+    oss << "Failed to enqueue kernel '"
+        << kernel_name <<"' on GPU "<< devuce.name()<<" : "<<what(err);
 		//LOG(ERROR)<<oss.str();
 		throw OpenCLSupportException(oss.str());
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '"<< kernel_name << "' executed on GPU "
+             << device.name();
 
 	CL_SET_KERNEL_ARG_END
 #endif
 
 
-	DLOG(INFO) << gpu->name() << "> set OpenCL memory at "<<gpu->getMemoryTag(virtualPtr).c_str()<<" to "<<alpha;
+  DLOG(INFO) << device.name() << "> set OpenCL memory at " <<
+                device.getMemoryTag(virtualPtr) << " to " << alpha;
 	return true;
 }
 template bool clMemset<char>(void* gpuPtr, const char alpha, const size_t N);
 template bool clMemset<int>(void* gpuPtr, const int alpha, const size_t N);
 template bool clMemset<float>(void* gpuPtr, const float alpha, const size_t N);
-template bool clMemset<double>(void* gpuPtr, const double alpha, const size_t N);
+template bool clMemset<double>(void* gpuPtr, const double alpha,
+                                const size_t N);
 
 template<typename T>
 bool clGPU2GPU(const void* src, void* dst, size_t Bytes) {
+  OpenCLPlatform& pf = OpenCLManager::CurrentPlatform();
+  OpenCLDevice& device = pf.CurrentDevice();
 
-	if ( ! gpu->isValidPtr(src) ) {
-		LOG(ERROR) << gpu->name() << "> not a valid memory pointer @ " << src;
+  if (!device.isValidPtr(src)) {
+    LOG(ERROR) << device.name() << "> not a valid memory pointer @ " << src;
 		return false;
 	}
 
 	OpenCLMemory clMemSrc;
-	if ( ! gpu->get(src, clMemSrc) ) {
-		LOG(ERROR) << gpu->name() << "> failed to get GPU memory @ " << src;
+  if (!device.get(src, clMemSrc)) {
+    LOG(ERROR) << device.name() << "> failed to get GPU memory @ " << src;
 		return false;
 	}
 	size_t offsetSrc	= clGetMemoryOffset(src);
 
-	if ( ! gpu->isValidPtr(dst) ) {
-		LOG(ERROR) << gpu->name() << "> not a valid memory pointer @ " << dst;
+  if (!device.isValidPtr(dst)) {
+    LOG(ERROR) << device.name() << "> not a valid memory pointer @ " << dst;
 		return false;
 	}
 
 	OpenCLMemory clMemDst;
-	if ( ! gpu->get(dst, clMemDst) ) {
-		LOG(ERROR) << gpu->name() << "> failed to get GPU memory @ " << dst;
+  if (!device.get(dst, clMemDst)) {
+    LOG(ERROR) << device.name() << "> failed to get GPU memory @ " << dst;
 		return false;
 	}
 	size_t offsetDst	= clGetMemoryOffset(dst);
 
-	queue = gpu->getQueue();
-	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+  cl_command_queue* queue = device.getQueue();
+  if (!queue) {
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
 	std::string kernel_name = clGetKernelName<T>("clGPU2GPU");
 
-	kernel = gpu->getKernel(kernel_name);
-	if ( kernel == NULL ) {
+  cl_kernel* kernel = device.getKernel(kernel_name);
+  if (kernel == NULL) {
 		return false;
 	}
 
 	unsigned int N = Bytes/sizeof(T);
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, N)
-	CL_SET_ARRAY_KERNEL_ARG(&src)
-	CL_SET_TYPE_KERNEL_ARG(int, (int) offsetSrc)
-	CL_SET_ARRAY_KERNEL_ARG(&dst)
-	CL_SET_TYPE_KERNEL_ARG(int, (int) offsetDst)
+  CL_SET_TYPE_KERNEL_ARG(int, N, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&src, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, (int) offsetSrc, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&dst, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, (int) offsetDst, kernel)
 
 	size_t global = 1024;//CAFFE_GET_GLOBAL_WORKITEMS(N, OPENCL_LOCAL_SIZE);
 	size_t local  = 1024;//CAFFE_GET_LOCAL_WORKITEMS(N, OPENCL_LOCAL_SIZE);
 
 	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
-	if ( err != CL_SUCCESS ) {
+  if (err != CL_SUCCESS) {
 		std::ostringstream oss;
-		oss << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<what(err);
+    oss << "Failed to enqueue kernel '" << kernel_name
+        << "' on GPU "<< device.name() << " : " << what(err);
 		throw OpenCLSupportException(oss.str());
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '" << kernel_name
+             << "' executed on GPU " << device.name();
 
 	CL_SET_KERNEL_ARG_END
-
 
 	return true;
 }
@@ -531,12 +462,14 @@ template bool clGPU2GPU<double>(const void* src, void* dst, size_t Bytes);
 
 
 bool clMemcpy(void* virtualDstPtr, const void* virtualSrcPtr, size_t size, int type) {
+  OpenCLPlatform& pf = OpenCLManager::CurrentPlatform();
+  OpenCLDevice& device = pf.CurrentDevice();
 
 	std::string function = __func__;
 
-	queue = gpu->getQueue();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
@@ -549,107 +482,126 @@ bool clMemcpy(void* virtualDstPtr, const void* virtualSrcPtr, size_t size, int t
 
 	case caffe::OpenCL::COPY_CPU_TO_CPU:
 		/*
-		if ( gpu->isValidPtr(src) ) {
-			LOG(ERROR) << gpu->name() << "> src pointer is in GPU memory @ " << src;
+    if ( device.isValidPtr(src) ) {
+      LOG(ERROR) << device.name() << "> src pointer is in GPU memory @ " << src;
 			return false;
 		}
 		*/
-		if ( gpu->isValidPtr(virtualDstPtr) ) {
-			LOG(ERROR) << gpu->name() << "> dst pointer is in GPU memory @ " << virtualDstPtr;
+    if (device.isValidPtr(virtualDstPtr)) {
+      LOG(ERROR) << device.name()
+                 << "> dst pointer is in GPU memory @ " << virtualDstPtr;
 			return false;
 		}
 		memcpy(virtualDstPtr, virtualSrcPtr, size);
-		DLOG(INFO) << gpu->name() << "> copy CPU@"<<virtualSrcPtr<<" to CPU@"<<virtualDstPtr<<" "<<size<<" Byte transferred.";
+    DLOG(INFO) << device.name() << "> copy CPU@" << virtualSrcPtr
+               << " to CPU@" << virtualDstPtr << " " << size
+               << " Byte transferred.";
 		break;
-
 	case caffe::OpenCL::COPY_CPU_TO_GPU:
 		/*
-		if ( gpu->isValidPtr(src) ) {
-			LOG(ERROR) << gpu->name() << "> src pointer is in GPU memory @ " << src;
+    if ( device.isValidPtr(src) ) {
+      LOG(ERROR) << device.name() << "> src pointer is in GPU memory @ " << src;
 			return false;
 		}
 		*/
-		if ( ! gpu->isValidPtr(virtualDstPtr) ) {
-			LOG(ERROR) << gpu->name() << "> dst pointer is not in GPU memory @ " << virtualDstPtr;
+    if (!device.isValidPtr(virtualDstPtr)) {
+      LOG(ERROR) << device.name() << "> dst pointer is not in GPU memory @ "
+                 << virtualDstPtr;
 			return false;
 		}
 
-		if ( ! gpu->get(virtualDstPtr, clMemDst) ) {
-			LOG(ERROR) << gpu->name() << "> failed to get GPU memory @ " << virtualDstPtr;
+    if (!device.get(virtualDstPtr, clMemDst)) {
+      LOG(ERROR) << device.name() << "> failed to get GPU memory @ "
+                 << virtualDstPtr;
 			return false;
 		}
 		baseDst 	= clMemDst.getLogicalPointer();
 		offsetDst	= clGetMemoryOffset(virtualDstPtr);
 
-		if ( ! CL_CHECK(clEnqueueWriteBuffer(*queue, (cl_mem) baseDst, CL_TRUE, offsetDst, size, virtualSrcPtr, 0, NULL, NULL) ) ) {
-			LOG(ERROR) << gpu->name() << "> copy CPU@"<<virtualSrcPtr<<" to "<<gpu->getMemoryTag(virtualDstPtr).c_str()<<" "<<size<<" Byte transferred failed.";
+    if ( ! CL_CHECK(clEnqueueWriteBuffer(*queue, (cl_mem) baseDst, CL_TRUE,
+                                         offsetDst, size, virtualSrcPtr,
+                                         0, NULL, NULL) ) ) {
+      LOG(ERROR) << device.name() << "> copy CPU@" << virtualSrcPtr
+                 << " to " << device.getMemoryTag(virtualDstPtr).c_str()
+                 << " " << size << " Byte transferred failed.";
 			return false;
 		};
 		//clFinish(*queue);
-		DLOG(INFO) << gpu->name() << "> copy CPU@"<<virtualSrcPtr<<" to "<<gpu->getMemoryTag(virtualDstPtr).c_str()<<" "<<size<<" Byte transferred.";
+    DLOG(INFO) << device.name() << "> copy CPU@" << virtualSrcPtr << " to "
+               << device.getMemoryTag(virtualDstPtr) << " " << size
+               << " Byte transferred.";
 		break;
-
 	case caffe::OpenCL::COPY_GPU_TO_CPU:
-		if ( ! gpu->isValidPtr(virtualSrcPtr) ) {
-			LOG(ERROR) << gpu->name() << "> src pointer is not in GPU memory @ " << virtualSrcPtr;
+    if (!device.isValidPtr(virtualSrcPtr) ) {
+      LOG(ERROR) << device.name() << "> src pointer is not in GPU memory @ " << virtualSrcPtr;
 			return false;
 		}
 		/*
-		if ( gpu->isValidPtr(dst) ) {
-			LOG(ERROR) << gpu->name() << "> dst pointer is in GPU memory @ " << dst;
+    if ( device.isValidPtr(dst) ) {
+      LOG(ERROR) << device.name() << "> dst pointer is in GPU memory @ " << dst;
 			return false;
 		}
 		*/
-		if ( ! gpu->get(virtualSrcPtr, clMemSrc) ) {
-			LOG(ERROR) << gpu->name() << "> failed to get GPU memory @ " << virtualSrcPtr;
+    if (!device.get(virtualSrcPtr, clMemSrc)) {
+      LOG(ERROR) << device.name() << "> failed to get GPU memory @ "
+                 << virtualSrcPtr;
 			return false;
 		}
 		baseSrc 	= clMemSrc.getLogicalPointer();
 		offsetSrc	= clGetMemoryOffset(virtualSrcPtr);
 
-		if ( ! CL_CHECK(clEnqueueReadBuffer(*queue, (cl_mem) baseSrc, CL_TRUE, offsetSrc, size, virtualDstPtr, 0, NULL, NULL) ) ) {
+    if (!CL_CHECK(clEnqueueReadBuffer(*queue, (cl_mem) baseSrc, CL_TRUE,
+                                      offsetSrc, size, virtualDstPtr, 0,
+                                      NULL, NULL) ) ) {
 			return false;
 		};
 		//clFinish(*queue);
-		DLOG(INFO) << gpu->name() << "> copy "<<gpu->getMemoryTag(virtualSrcPtr).c_str()<<" to CPU@"<<virtualDstPtr<<" "<<size<<" Byte transferred.";
+    DLOG(INFO) << device.name() << "> copy "
+               << device.getMemoryTag(virtualSrcPtr) << " to CPU@"
+               << virtualDstPtr << " " << size << " Byte transferred.";
 		break;
 
 	case caffe::OpenCL::COPY_GPU_TO_GPU:
-		if ( ! gpu->isValidPtr(virtualSrcPtr) ) {
-			LOG(ERROR) << gpu->name() << "> src pointer is not in GPU memory @ " << virtualSrcPtr;
+    if (!device.isValidPtr(virtualSrcPtr)) {
+      LOG(ERROR) << device.name() << "> src pointer is not in GPU memory @ "
+                 << virtualSrcPtr;
 			return false;
 		}
-		if ( ! gpu->isValidPtr(virtualDstPtr) ) {
-			LOG(ERROR) << gpu->name() << "> dst pointer is not in GPU memory @ " << virtualDstPtr;
+    if (!device.isValidPtr(virtualDstPtr)) {
+      LOG(ERROR) << device.name() << "> dst pointer is not in GPU memory @ "
+                 << virtualDstPtr;
 			return false;
 		}
-		DLOG(INFO) << "VMS@"<<virtualSrcPtr<<" to VMD@"<<virtualDstPtr<<" size = "<<size;
+    DLOG(INFO) << "VMS@" << virtualSrcPtr << " to VMD@"
+               << virtualDstPtr << " size = " << size;
 
-		if ( ! gpu->get(virtualSrcPtr, clMemSrc) ) {
-			LOG(ERROR) << gpu->name() << "> failed to get GPU memory @ " << virtualSrcPtr;
+    if (!device.get(virtualSrcPtr, clMemSrc)) {
+      LOG(ERROR) << device.name() << "> failed to get GPU memory @ "
+                 << virtualSrcPtr;
 			return false;
 		}
 		baseSrc 	= clMemSrc.getLogicalPointer();
 		offsetSrc	= clGetMemoryOffset(virtualSrcPtr);
-		DLOG(INFO) << gpu->getMemoryTag(clMemSrc.getVirtualPointer()).c_str();
+    DLOG(INFO) << device.getMemoryTag(clMemSrc.getVirtualPointer()).c_str();
 		DLOG(INFO) << "VMS@"<<baseSrc<<" offset = "<<offsetSrc;
 
-		if ( ! gpu->get(virtualDstPtr, clMemDst) ) {
-			LOG(ERROR) << gpu->name() << "> failed to get GPU memory @ " << virtualDstPtr;
+    if (!device.get(virtualDstPtr, clMemDst) ) {
+      LOG(ERROR) << device.name() << "> failed to get GPU memory @ "
+                 << virtualDstPtr;
 			return false;
 		}
 		baseDst 	= clMemDst.getLogicalPointer();
 		offsetDst	= clGetMemoryOffset(virtualDstPtr);
-		DLOG(INFO) << gpu->getMemoryTag(clMemDst.getVirtualPointer()).c_str();
-		DLOG(INFO) << "VMD@"<<baseDst<<" offset = "<<offsetDst;
+    DLOG(INFO) << device.getMemoryTag(clMemDst.getVirtualPointer());
+    DLOG(INFO) << "VMD@" << baseDst << " offset = " << offsetDst;
 
-		if ( offsetSrc + size > clMemSrc.getSize() ) {
-			LOG(ERROR) << gpu->name() << "> copy range out of source range.";
+    if (offsetSrc + size > clMemSrc.getSize()) {
+      LOG(ERROR) << device.name() << "> copy range out of source range.";
 			return false;
 		}
 
-		if ( offsetDst + size > clMemDst.getSize() ) {
-			LOG(ERROR) << gpu->name() << "> copy range out of destination range.";
+    if (offsetDst + size > clMemDst.getSize()) {
+      LOG(ERROR) << device.name() << "> copy range out of destination range.";
 			return false;
 		}
 
@@ -667,14 +619,16 @@ bool clMemcpy(void* virtualDstPtr, const void* virtualSrcPtr, size_t size, int t
 
 			DLOG(INFO) << "no overlap";
 			/*
-			DLOG(INFO) << gpu->getMemoryTag(baseSrc).c_str();
-			DLOG(INFO) << gpu->getMemoryTag(baseDst).c_str();
+      DLOG(INFO) << device.getMemoryTag(baseSrc).c_str();
+      DLOG(INFO) << device.getMemoryTag(baseDst).c_str();
 			DLOG(INFO) << "offset Src = "<<offsetSrc;
 			DLOG(INFO) << "offset Dst = "<<offsetDst;
 			DLOG(INFO) << "size       = "<<size;
 			*/
 
-			if ( ! CL_CHECK( clEnqueueCopyBuffer(*queue, (cl_mem) baseSrc, (cl_mem) baseDst, offsetSrc, offsetDst, size, 0, NULL, NULL) ) ) {
+      if ( ! CL_CHECK( clEnqueueCopyBuffer(*queue, (cl_mem) baseSrc,
+                                           (cl_mem) baseDst, offsetSrc,
+                                           offsetDst, size, 0, NULL, NULL) ) ) {
 				return false;
 			}
 			//clFinish(*queue);
@@ -684,54 +638,56 @@ bool clMemcpy(void* virtualDstPtr, const void* virtualSrcPtr, size_t size, int t
 			//clGPU2GPU<char>(clMemSrc.getVirtualPointer(), clMemDst.getVirtualPointer(), size);
 
 			void* bufVPtr = NULL;
-			if ( ! clMalloc(&bufVPtr, size) ) {
-				LOG(ERROR) << gpu->name() << "> failed to created buffer of size = " << size << " Byte";
+      if (!clMalloc(&bufVPtr, size) ) {
+        LOG(ERROR) << device.name() << "> failed to created buffer of size = "
+                   << size << " Byte";
 				return false;
 			}
 
 			OpenCLMemory buffer;
-			if ( ! gpu->get(bufVPtr, buffer) ) {
-				LOG(ERROR) << gpu->name() << "> failed to get buffer Object GPU@VIRT"<<bufVPtr;
+      if (!device.get(bufVPtr, buffer) ) {
+        LOG(ERROR) << device.name() << "> failed to get buffer Object GPU@VIRT"
+                   << bufVPtr;
 				return false;
 			}
 			const void* bufLPtr = buffer.getLogicalPointer();
 
 			/*
-			DLOG(INFO) << "src = "<<gpu->getMemoryTag(virtualSrcPtr).c_str();
-			DLOG(INFO) << "buf = "<<gpu->getMemoryTag(bufVPtr).c_str();
-			DLOG(INFO) << "dst = "<<gpu->getMemoryTag(virtualDstPtr).c_str();
+      DLOG(INFO) << "src = "<<device.getMemoryTag(virtualSrcPtr).c_str();
+      DLOG(INFO) << "buf = "<<device.getMemoryTag(bufVPtr).c_str();
+      DLOG(INFO) << "dst = "<<device.getMemoryTag(virtualDstPtr).c_str();
 			DLOG(INFO) << "offset Src = "<<offsetSrc;
 			DLOG(INFO) << "offset Dst = "<<offsetDst;
 			DLOG(INFO) << "size       = "<<size;
 			*/
 
-			if ( ! CL_CHECK( clEnqueueCopyBuffer(*queue, (cl_mem) baseSrc, (cl_mem) bufLPtr, offsetSrc, 0, size, 0, NULL, NULL) ) ) {
+      if (!CL_CHECK(clEnqueueCopyBuffer(*queue, (cl_mem) baseSrc, (cl_mem) bufLPtr, offsetSrc, 0, size, 0, NULL, NULL) ) ) {
 				return false;
 			}
-			DLOG(INFO) << gpu->name() << "> copy "<<gpu->getMemoryTag(virtualSrcPtr).c_str()<<" with offset " << offsetSrc << " to buffer " <<gpu->getMemoryTag(bufVPtr).c_str()<< " "<<size<<" Byte transferred.";
+      DLOG(INFO) << device.name() << "> copy "<<device.getMemoryTag(virtualSrcPtr).c_str()<<" with offset " << offsetSrc << " to buffer " <<device.getMemoryTag(bufVPtr).c_str()<< " "<<size<<" Byte transferred.";
 
 			if ( ! CL_CHECK( clEnqueueCopyBuffer(*queue, (cl_mem) bufLPtr, (cl_mem) baseDst, 0, offsetDst, size, 0, NULL, NULL) ) ) {
 				return false;
 			}
-			DLOG(INFO) << gpu->name() << "> copy "<<gpu->getMemoryTag(bufVPtr).c_str()<<" to "<<gpu->getMemoryTag(virtualDstPtr).c_str()<<" with offset "<<offsetDst<<" "<<size<<" Byte transferred.";
+      DLOG(INFO) << device.name() << "> copy "<<device.getMemoryTag(bufVPtr).c_str()<<" to "<<device.getMemoryTag(virtualDstPtr).c_str()<<" with offset "<<offsetDst<<" "<<size<<" Byte transferred.";
 
 			clFree(bufVPtr);
 		}
 
-		DLOG(INFO) << gpu->name() << "> copy "<<gpu->getMemoryTag(virtualSrcPtr).c_str()<<" with offset " << offsetSrc << " to "<<gpu->getMemoryTag(virtualDstPtr).c_str()<<" with offset " << offsetDst << " "<<size<<" Byte transferred.";
+    DLOG(INFO) << device.name() << "> copy "<<device.getMemoryTag(virtualSrcPtr).c_str()<<" with offset " << offsetSrc << " to "<<device.getMemoryTag(virtualDstPtr).c_str()<<" with offset " << offsetDst << " "<<size<<" Byte transferred.";
 		break;
 
 	case caffe::OpenCL::COPY_DEFAULT:
-		if ( ! gpu->isValidPtr(virtualSrcPtr) && ! gpu->isValidPtr(virtualDstPtr) ) {
+    if ( ! device.isValidPtr(virtualSrcPtr) && ! device.isValidPtr(virtualDstPtr) ) {
 			return clMemcpy(virtualDstPtr, virtualSrcPtr, size, caffe::OpenCL::COPY_CPU_TO_CPU);
 		}
-		if ( ! gpu->isValidPtr(virtualSrcPtr) && gpu->isValidPtr(virtualDstPtr) ) {
+    if ( ! device.isValidPtr(virtualSrcPtr) && device.isValidPtr(virtualDstPtr) ) {
 			return clMemcpy(virtualDstPtr, virtualSrcPtr, size, caffe::OpenCL::COPY_CPU_TO_GPU);
 		}
-		if ( gpu->isValidPtr(virtualSrcPtr) && ! gpu->isValidPtr(virtualDstPtr) ) {
+    if ( device.isValidPtr(virtualSrcPtr) && ! device.isValidPtr(virtualDstPtr) ) {
 			return clMemcpy(virtualDstPtr, virtualSrcPtr, size, caffe::OpenCL::COPY_GPU_TO_CPU);
 		}
-		if ( gpu->isValidPtr(virtualSrcPtr) && gpu->isValidPtr(virtualDstPtr) ) {
+    if ( device.isValidPtr(virtualSrcPtr) && device.isValidPtr(virtualDstPtr) ) {
 			return clMemcpy(virtualDstPtr, virtualSrcPtr, size, caffe::OpenCL::COPY_GPU_TO_GPU);
 		}
 		break;
@@ -771,7 +727,12 @@ bool clReleaseBufferMap(std::map<const void*, std::pair<void*, size_t> >& buffer
 	return true;
 }
 
-bool clSetKernelArrayArg(const void* ptr_virtual, unsigned int& idx, std::vector<cl_mem>& subBuffers, std::map<const void*, std::pair<void*, size_t> >& bufferMap) {
+bool clSetKernelArrayArg(const void* ptr_virtual, unsigned int& idx,
+                         std::vector<cl_mem>& subBuffers,
+                         std::map<const void*,
+                         std::pair<void*, size_t> >& bufferMap,
+                         cl_kernel* kernel) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
 	cl_int err;
 
@@ -780,7 +741,9 @@ bool clSetKernelArrayArg(const void* ptr_virtual, unsigned int& idx, std::vector
 		DLOG(INFO)<<"kernel variable pointer is NULL for kernel argument "<<idx;
 		err = clSetKernelArg(*kernel, idx, sizeof(cl_mem), NULL);
 		if ( err != CL_SUCCESS ) {
-			LOG(ERROR) << "failed to set kernel argument "<<idx<<" for kernel on GPU "<<gpu->name()<<" : "<<what(err);
+      LOG(ERROR) << "failed to set kernel argument "
+                 << idx<<" for kernel on GPU "
+                 << device.name() << " : "<< what(err);
 			return false;
 		}
 		idx++;
@@ -800,7 +763,7 @@ bool clSetKernelArrayArg(const void* ptr_virtual, unsigned int& idx, std::vector
 	if ( offset == 0 ) {
 		err = clSetKernelArg(*kernel, idx, sizeof(ptr_logical), &ptr_logical);
 		if ( err != CL_SUCCESS ) {
-			LOG(ERROR) << "failed to set kernel argument "<<idx<<" for kernel on GPU "<<gpu->name()<<" : "<<what(err);
+      LOG(ERROR) << "failed to set kernel argument "<<idx<<" for kernel on GPU "<<device.name()<<" : "<<what(err);
 			return false;
 		}
 		idx++;
@@ -808,7 +771,7 @@ bool clSetKernelArrayArg(const void* ptr_virtual, unsigned int& idx, std::vector
 	}
 
 	/* check alignment */
-	cl_uint bytes = gpu->getDeviceMemBaseAddrAlign();
+  cl_uint bytes = device.getDeviceMemBaseAddrAlign();
 	if ( offset % bytes != 0 ) {
 		LOG(WARNING)<<"sub-buffer memory offset ("<<offset<<" Byte) is not aligned with device memory offset ("<<bytes<<" Byte)";
 
@@ -836,7 +799,7 @@ bool clSetKernelArrayArg(const void* ptr_virtual, unsigned int& idx, std::vector
 
 		err = clSetKernelArg(*kernel, idx, sizeof(ptr_logical), &ptr_logical);
 		if ( err != CL_SUCCESS ) {
-			LOG(ERROR) << "failed to set kernel argument "<<idx<<" for kernel on GPU "<<gpu->name()<<" : "<<what(err);
+      LOG(ERROR) << "failed to set kernel argument "<<idx<<" for kernel on GPU "<<device.name()<<" : "<<what(err);
 			return false;
 		}
 		idx++;
@@ -848,7 +811,7 @@ bool clSetKernelArrayArg(const void* ptr_virtual, unsigned int& idx, std::vector
 	cl_buffer_region region = {offset, size - offset};
 	cl_mem sb = clCreateSubBuffer((cl_mem) ptr_logical, CL_MEM_READ_WRITE, CL_BUFFER_CREATE_TYPE_REGION, &region, &err);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "failed to create sub-buffer for kernel argument "<<idx<<" for kernel on GPU "<<gpu->name()<<" : "<<what(err);
+    LOG(ERROR) << "failed to create sub-buffer for kernel argument "<<idx<<" for kernel on GPU "<<device.name()<<" : "<<what(err);
 		return false;
 	}
 	DLOG(INFO)<<"create sub-buffer "<<subBuffers.size()<<std::endl;
@@ -856,7 +819,7 @@ bool clSetKernelArrayArg(const void* ptr_virtual, unsigned int& idx, std::vector
 
 	err = clSetKernelArg(*kernel, idx, sizeof(sb), &sb);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "failed to set kernel argument "<<idx<<" for kernel on GPU "<<gpu->name()<<" : "<<what(err);
+    LOG(ERROR) << "failed to set kernel argument "<<idx<<" for kernel on GPU "<<device.name()<<" : "<<what(err);
 		return false;
 	}
 	idx++;
@@ -865,33 +828,35 @@ bool clSetKernelArrayArg(const void* ptr_virtual, unsigned int& idx, std::vector
 }
 
 template<typename T>
-bool clSetKernelTypeArg(T variable, unsigned int& idx) {
+bool clSetKernelTypeArg(T variable, unsigned int& idx, cl_kernel* kernel) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
 	cl_int err;
 
-	err = clSetKernelArg(*kernel, idx, sizeof(T), &variable);
+  err = clSetKernelArg(*kernel, idx, sizeof(T), &variable);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "failed to set kernel argument "<<idx<<" for kernel on GPU "<<gpu->name()<<" : "<<what(err);\
+    LOG(ERROR) << "failed to set kernel argument "<<idx<<" for kernel on GPU "<<device.name()<<" : "<<what(err);\
 		return false;
 	}
 	idx++;
 	return true;
 }
-template bool clSetKernelTypeArg<int>(int variable, unsigned int& idx);
-template bool clSetKernelTypeArg<const int>(const int variable, unsigned int& idx);
-template bool clSetKernelTypeArg<unsigned int>(unsigned int variable, unsigned int& idx);
-template bool clSetKernelTypeArg<const unsigned int>(const unsigned int variable, unsigned int& idx);
-template bool clSetKernelTypeArg<float>(float variable, unsigned int& idx);
-template bool clSetKernelTypeArg<const float>(const float variable, unsigned int& idx);
-template bool clSetKernelTypeArg<double>(double variable, unsigned int& idx);
-template bool clSetKernelTypeArg<const double>(const double variable, unsigned int& idx);
+template bool clSetKernelTypeArg<int>(int variable, unsigned int& idx, cl_kernel* kernel);
+template bool clSetKernelTypeArg<const int>(const int variable, unsigned int& idx, cl_kernel* kernel);
+template bool clSetKernelTypeArg<unsigned int>(unsigned int variable, unsigned int& idx, cl_kernel* kernel);
+template bool clSetKernelTypeArg<const unsigned int>(const unsigned int variable, unsigned int& idx, cl_kernel* kernel);
+template bool clSetKernelTypeArg<float>(float variable, unsigned int& idx, cl_kernel* kernel);
+template bool clSetKernelTypeArg<const float>(const float variable, unsigned int& idx, cl_kernel* kernel);
+template bool clSetKernelTypeArg<double>(double variable, unsigned int& idx, cl_kernel* kernel);
+template bool clSetKernelTypeArg<const double>(const double variable, unsigned int& idx, cl_kernel* kernel);
 
 template<typename T>
 bool clBLASasum(const int N, const void* array_virtual, T* y) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
-	queue = gpu->getQueue();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
@@ -934,35 +899,36 @@ template bool clBLASasum<double>(const int N, const void* array_GPU_ptr, double*
 
 template<typename T>
 bool clsign(const int n, const void* array_GPU_x, void* array_GPU_y) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
 	std::string kernel_name = clGetKernelName<T>("clsign");
 
-	queue = gpu->getQueue();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
-	kernel = gpu->getKernel(kernel_name);
+  cl_kernel* kernel = device.getKernel(kernel_name);
 	if ( kernel == NULL ) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, n)
-	CL_SET_ARRAY_KERNEL_ARG(&array_GPU_x)
-	CL_SET_ARRAY_KERNEL_ARG(&array_GPU_y)
+  CL_SET_TYPE_KERNEL_ARG(int, n, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&array_GPU_x, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&array_GPU_y, kernel)
 
 	size_t global = CAFFE_GET_GLOBAL_WORKITEMS(n, OPENCL_LOCAL_SIZE);
 	size_t local  = CAFFE_GET_LOCAL_WORKITEMS(n, OPENCL_LOCAL_SIZE);
 
 	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+    LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<device.name()<<" : "<<caffe::OpenCL::what(err);
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<device.name();
 
 	CL_SET_KERNEL_ARG_END
 
@@ -973,35 +939,36 @@ template bool clsign<double>(const int n, const void* array_GPU_x, void* array_G
 
 template<typename T>
 bool clsgnbit(const int n, const void* array_GPU_x, void* array_GPU_y) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
 	std::string kernel_name = clGetKernelName<T>("clsgnbit");
 
-	queue = gpu->getQueue();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
-	kernel = gpu->getKernel(kernel_name);
+  cl_kernel* kernel = device.getKernel(kernel_name);
 	if ( kernel == NULL ) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, n)
-	CL_SET_ARRAY_KERNEL_ARG(&array_GPU_x)
-	CL_SET_ARRAY_KERNEL_ARG(&array_GPU_y)
+  CL_SET_TYPE_KERNEL_ARG(int, n, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&array_GPU_x, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&array_GPU_y, kernel)
 
 	size_t global = CAFFE_GET_GLOBAL_WORKITEMS(n, OPENCL_LOCAL_SIZE);
 	size_t local  = CAFFE_GET_LOCAL_WORKITEMS(n, OPENCL_LOCAL_SIZE);
 
 	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+    LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<device.name()<<" : "<<caffe::OpenCL::what(err);
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<device.name();
 
 	CL_SET_KERNEL_ARG_END
 
@@ -1012,35 +979,36 @@ template bool clsgnbit<double>(const int n, const void* array_GPU_x, void* array
 
 template<typename T>
 bool clabs(const int n, const void* array_GPU_x, void* array_GPU_y) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
 	std::string kernel_name = clGetKernelName<T>("clabs");
 
-	queue = gpu->getQueue();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
-	kernel = gpu->getKernel(kernel_name);
+  cl_kernel* kernel = device.getKernel(kernel_name);
 	if ( kernel == NULL ) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, n)
-	CL_SET_ARRAY_KERNEL_ARG(&array_GPU_x)
-	CL_SET_ARRAY_KERNEL_ARG(&array_GPU_y)
+  CL_SET_TYPE_KERNEL_ARG(int, n, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&array_GPU_x, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&array_GPU_y, kernel)
 
 	size_t global = CAFFE_GET_GLOBAL_WORKITEMS(n, OPENCL_LOCAL_SIZE);
 	size_t local  = CAFFE_GET_LOCAL_WORKITEMS(n, OPENCL_LOCAL_SIZE);
 
 	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+    LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<device.name()<<" : "<<caffe::OpenCL::what(err);
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<device.name();
 
 	CL_SET_KERNEL_ARG_END
 
@@ -1051,36 +1019,37 @@ template bool clabs<double>(const int n, const void* array_GPU_x, void* array_GP
 
 template<typename T>
 bool cldiv(const int n, const void* array_GPU_x, const void* array_GPU_y, void* array_GPU_z) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
 	std::string kernel_name = clGetKernelName<T>("cldiv");
 
-	queue = gpu->getQueue();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
-	kernel = gpu->getKernel(kernel_name);
+  cl_kernel* kernel = device.getKernel(kernel_name);
 	if ( kernel == NULL ) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, n)
-	CL_SET_ARRAY_KERNEL_ARG(&array_GPU_x)
-	CL_SET_ARRAY_KERNEL_ARG(&array_GPU_y)
-	CL_SET_ARRAY_KERNEL_ARG(&array_GPU_z)
+  CL_SET_TYPE_KERNEL_ARG(int, n, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&array_GPU_x, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&array_GPU_y, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&array_GPU_z, kernel)
 
 	size_t global = CAFFE_GET_GLOBAL_WORKITEMS(n, OPENCL_LOCAL_SIZE);
 	size_t local  = CAFFE_GET_LOCAL_WORKITEMS(n, OPENCL_LOCAL_SIZE);
 
 	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+    LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<device.name()<<" : "<<caffe::OpenCL::what(err);
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<device.name();
 
 	CL_SET_KERNEL_ARG_END
 
@@ -1091,36 +1060,37 @@ template bool cldiv<double>(const int n, const void* array_GPU_x, const void* ar
 
 template<typename T>
 bool clmul(const int n, const void* array_GPU_x, const void* array_GPU_y, void* array_GPU_z) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
 	std::string kernel_name = clGetKernelName<T>("clmul");
 
-	queue = gpu->getQueue();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
-	kernel = gpu->getKernel(kernel_name);
+  cl_kernel* kernel = device.getKernel(kernel_name);
 	if ( kernel == NULL ) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, n)
-	CL_SET_ARRAY_KERNEL_ARG(&array_GPU_x)
-	CL_SET_ARRAY_KERNEL_ARG(&array_GPU_y)
-	CL_SET_ARRAY_KERNEL_ARG(&array_GPU_z)
+  CL_SET_TYPE_KERNEL_ARG(int, n, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&array_GPU_x, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&array_GPU_y, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&array_GPU_z, kernel)
 
 	size_t global = CAFFE_GET_GLOBAL_WORKITEMS(n, OPENCL_LOCAL_SIZE);
 	size_t local  = CAFFE_GET_LOCAL_WORKITEMS(n, OPENCL_LOCAL_SIZE);
 
 	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+    LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<device.name()<<" : "<<caffe::OpenCL::what(err);
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<device.name();
 
 	CL_SET_KERNEL_ARG_END
 
@@ -1131,10 +1101,11 @@ template bool clmul<double>(const int n, const void* array_GPU_x, const void* ar
 
 template<typename T>
 bool clBLASscal(const int n, const float alpha, const void* array_x_virtual, void* array_y_virtual) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
-	queue = gpu->getQueue();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
@@ -1151,22 +1122,22 @@ bool clBLASscal(const int n, const float alpha, const void* array_x_virtual, voi
 
 	if( typeid(T) == typeid(float) ) {
 		if ( ! CL_CHECK( clblasScopy(n, (cl_mem) array_x_logical, 0, 1, (cl_mem) array_y_logical, 0, 1, 1, queue, 0, NULL, NULL) ) ) {
-			LOG(ERROR) << "clblasScopy() failed on GPU "<<gpu->name();
+      LOG(ERROR) << "clblasScopy() failed on GPU "<<device.name();
 			return false;
 		}
 		if ( ! CL_CHECK( clblasSscal(n, alpha, (cl_mem) array_y_logical, 0, 1, 1, queue, 0, NULL, NULL) ) ) {
-			LOG(ERROR) << "clblasSscal() failed on GPU "<<gpu->name();
+      LOG(ERROR) << "clblasSscal() failed on GPU "<<device.name();
 			return false;
 		}
 	}
 
 	if( typeid(T) == typeid(double) ) {
 		if ( ! CL_CHECK( clblasDcopy(n, (cl_mem) array_x_logical, 0, 1, (cl_mem) array_y_logical, 0, 1, 1, queue, 0, NULL, NULL) ) ) {
-			LOG(ERROR) << "clblasDcopy() failed on GPU "<<gpu->name();
+      LOG(ERROR) << "clblasDcopy() failed on GPU "<<device.name();
 			return false;
 		}
 		if ( ! CL_CHECK( clblasDscal(n, alpha, (cl_mem) array_y_logical, 0, 1, 1, queue, 0, NULL, NULL) ) ) {
-			LOG(ERROR) << "clblasDscal() failed on GPU "<<gpu->name();
+      LOG(ERROR) << "clblasDscal() failed on GPU "<<device.name();
 			return false;
 		}
 	}
@@ -1178,16 +1149,17 @@ template bool clBLASscal<double>(const int n, const float alpha, const void* arr
 
 template<typename T>
 bool clBLASdot(const int n, const T* x, const int incx, const T* y, const int incy, T* out) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
-	queue = gpu->getQueue();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
 	/*
 	OpenCLMemory clMem;
-	if ( ! gpu->get(x, clMem) ) {
+  if ( ! device.get(x, clMem) ) {
 		return false;
 	}
 	DLOG(INFO)<<"x : "<<clMem.getTag().c_str();
@@ -1201,7 +1173,7 @@ bool clBLASdot(const int n, const T* x, const int incx, const T* y, const int in
 	}
 
 	/*
-	if ( ! gpu->get(y, clMem) ) {
+  if ( ! device.get(y, clMem) ) {
 		return false;
 	}
 	DLOG(INFO)<<"y : "<<clMem.getTag().c_str();
@@ -1227,22 +1199,22 @@ bool clBLASdot(const int n, const T* x, const int incx, const T* y, const int in
 
 	if( typeid(T) == typeid(float) ) {
 		if ( ! CL_CHECK( clblasSdot(n, (cl_mem) dot_logical, 0, (cl_mem) x_logical, 0, 1, (cl_mem) y_logical, 0, 1, (cl_mem) buf_logical, 1, queue, 0, NULL, NULL) ) ) {
-			LOG(ERROR) << "clblasSdot() failed on GPU "<<gpu->name();
+      LOG(ERROR) << "clblasSdot() failed on GPU "<<device.name();
 			clReleaseSubBuffers(sb);
 			clReleaseBufferMap(bm);
 			return false;
 		}
-		DLOG(INFO) << "clblasSdot() succeeded on GPU "<<gpu->name();
+    DLOG(INFO) << "clblasSdot() succeeded on GPU "<<device.name();
 	}
 
 	if( typeid(T) == typeid(double) ) {
 		if ( ! CL_CHECK( clblasDdot(n, (cl_mem) dot_logical, 0, (cl_mem) x_logical, 0, 1, (cl_mem) y_logical, 0, 1, (cl_mem) buf_logical, 1, queue, 0, NULL, NULL) ) ) {
-			LOG(ERROR) << "clblasDdot() failed on GPU "<<gpu->name();
+      LOG(ERROR) << "clblasDdot() failed on GPU "<<device.name();
 			clReleaseSubBuffers(sb);
 			clReleaseBufferMap(bm);
 			return false;
 		}
-		DLOG(INFO) << "clblasDdot() succeeded on GPU "<<gpu->name();
+    DLOG(INFO) << "clblasDdot() succeeded on GPU "<<device.name();
 	}
 
 	clReleaseSubBuffers(sb);
@@ -1255,10 +1227,11 @@ template bool clBLASdot<double>(const int n, const double* x, const int incx, co
 
 template<typename T>
 bool clBLASgemv(const clblasTranspose TransA, const int m, const int n, const T alpha, const T* A, const T* x, const T beta, T* y) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
-	queue = gpu->getQueue();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
@@ -1336,22 +1309,22 @@ bool clBLASgemv(const clblasTranspose TransA, const int m, const int n, const T 
 
 	if( typeid(T) == typeid(float) ) {
 		if ( ! CL_CHECK( clblasSgemv(clblasRowMajor, TransA, m, n, alpha, (cl_mem) A_device, A_offset, n, (cl_mem) x_device, x_offset, 1, beta, (cl_mem) y_device, y_offset, 1, 1, queue, 0, NULL, NULL) ) ) {
-			LOG(ERROR) << "clblasSgemv() failed on GPU "<<gpu->name();
+      LOG(ERROR) << "clblasSgemv() failed on GPU "<<device.name();
 			//clReleaseSubBuffers(sb);
 			//clReleaseBufferMap(bm);
 			return false;
 		}
-		DLOG(INFO) << "clblasSgemv() succeeded on GPU "<<gpu->name();
+    DLOG(INFO) << "clblasSgemv() succeeded on GPU "<<device.name();
 	}
 
 	if( typeid(T) == typeid(double) ) {
 		if ( ! CL_CHECK( clblasDgemv(clblasRowMajor, TransA, m, n, alpha, (cl_mem) A_device, A_offset, n, (cl_mem) x_device, x_offset, 1, beta, (cl_mem) y_device, y_offset, 1, 1, queue, 0, NULL, NULL) ) ) {
-			LOG(ERROR) << "clblasDgemv() failed on GPU "<<gpu->name();
+      LOG(ERROR) << "clblasDgemv() failed on GPU "<<device.name();
 			//clReleaseSubBuffers(sb);
 			//clReleaseBufferMap(bm);
 			return false;
 		}
-		DLOG(INFO) << "clblasDgemv() succeeded on GPU "<<gpu->name();
+    DLOG(INFO) << "clblasDgemv() succeeded on GPU "<<device.name();
 	}
 	//clReleaseSubBuffers(sb);
 	//clReleaseBufferMap(bm);
@@ -1362,10 +1335,11 @@ template bool clBLASgemv<double>(const clblasTranspose TransA, const int m, cons
 
 template<typename T>
 bool clBLASgemv(const clblasTranspose TransA, const int m, const int n, const T alpha, const T* A, const int step_A, const T* x, const int step_x, const T beta, T* y, const int step_y) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
-	queue = gpu->getQueue();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
@@ -1386,18 +1360,18 @@ bool clBLASgemv(const clblasTranspose TransA, const int m, const int n, const T 
 
 	if( typeid(T) == typeid(float) ) {
 		if ( ! CL_CHECK( clblasSgemv(clblasRowMajor, TransA, m, n, alpha, (cl_mem) A_logical, step_A, n, (cl_mem) x_logical, step_x, 1, beta, (cl_mem) y_logical, step_y, 1, 1, queue, 0, NULL, NULL) ) ) {
-			LOG(ERROR) << "clblasSgemv() failed on GPU "<<gpu->name();
+      LOG(ERROR) << "clblasSgemv() failed on GPU "<<device.name();
 			return false;
 		}
-		DLOG(INFO) << "clblasSgemv() succeeded on GPU "<<gpu->name();
+    DLOG(INFO) << "clblasSgemv() succeeded on GPU "<<device.name();
 	}
 
 	if( typeid(T) == typeid(double) ) {
 		if ( ! CL_CHECK( clblasDgemv(clblasRowMajor, TransA, m, n, alpha, (cl_mem) A_logical, step_A, n, (cl_mem) x_logical, step_x, 1, beta, (cl_mem) y_logical, step_y, 1, 1, queue, 0, NULL, NULL) ) ) {
-			LOG(ERROR) << "clblasDgemv() failed on GPU "<<gpu->name();
+      LOG(ERROR) << "clblasDgemv() failed on GPU "<<device.name();
 			return false;
 		}
-		DLOG(INFO) << "clblasDgemv() succeeded on GPU "<<gpu->name();
+    DLOG(INFO) << "clblasDgemv() succeeded on GPU "<<device.name();
 	}
 
 	return true;
@@ -1407,27 +1381,29 @@ template bool clBLASgemv<double>(const clblasTranspose TransA, const int m, cons
 
 template<typename T>
 bool clgemm(const int m, const int n, const int k, const T* A, const T* B, T* C) {
+  OpenCLPlatform& pf = OpenCLManager::CurrentPlatform();
+  OpenCLDevice& device = pf.CurrentDevice();
 
-	queue = gpu->getQueue();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
 	std::string kernel_name = clGetKernelName<T>("mmul");
 
-	kernel = gpu->getKernel(kernel_name);
+  cl_kernel* kernel = device.getKernel(kernel_name);
 	if ( kernel == NULL ) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, m)
-	CL_SET_TYPE_KERNEL_ARG(int, n)
-	CL_SET_TYPE_KERNEL_ARG(int, k)
-	CL_SET_ARRAY_KERNEL_ARG(&A)
-	CL_SET_ARRAY_KERNEL_ARG(&B)
-	CL_SET_ARRAY_KERNEL_ARG(&C)
+  CL_SET_TYPE_KERNEL_ARG(int, m, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, n, kernel)
+  CL_SET_TYPE_KERNEL_ARG(int, k, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&A, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&B, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&C, kernel)
 	clSetKernelArg(*kernel, 6, sizeof(T)*k, NULL);
 
 	size_t global = n;//CAFFE_GET_GLOBAL_WORKITEMS(n, OPENCL_LOCAL_SIZE);
@@ -1436,12 +1412,12 @@ bool clgemm(const int m, const int n, const int k, const T* A, const T* B, T* C)
 	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
 		std::ostringstream oss;
-		oss << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<what(err);
+    oss << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<device.name()<<" : "<<what(err);
 		throw OpenCLSupportException(oss.str());
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<device.name();
 
 	CL_SET_KERNEL_ARG_END
 
@@ -1452,10 +1428,11 @@ template bool clgemm<double>(const int m, const int n, const int k, const double
 
 template<typename T>
 bool clBLASgemm(const clblasTranspose TransA, const clblasTranspose TransB, const int m, const int n, const int k, const T alpha, const T* A, const T* x, const T beta, T* y) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
-	queue = gpu->getQueue();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
@@ -1554,24 +1531,24 @@ bool clBLASgemm(const clblasTranspose TransA, const clblasTranspose TransB, cons
 
 	if( typeid(T) == typeid(float) ) {
 		if ( ! CL_CHECK( clblasSgemm(clblasRowMajor, TransA, TransB, m, n, k, alpha, (cl_mem) A_device, A_offset, lda, (cl_mem) x_device, x_offset, ldb, beta, (cl_mem) y_device, y_offset, ldc, 1, queue, 0, NULL, NULL) ) ) {
-			LOG(ERROR) << "clblasSgemm() failed on GPU "<<gpu->name();
+      LOG(ERROR) << "clblasSgemm() failed on GPU "<<device.name();
 			//clReleaseSubBuffers(sb);
 			//clReleaseBufferMap(bm);
 			return false;
 		}
 		////clFinish(*queue);
-		DLOG(INFO) << "clblasSgemm() succeeded on GPU "<<gpu->name();
+    DLOG(INFO) << "clblasSgemm() succeeded on GPU "<<device.name();
 	}
 
 	if( typeid(T) == typeid(double) ) {
 		if ( ! CL_CHECK( clblasDgemm(clblasRowMajor, TransA, TransB, m, n, k, alpha, (cl_mem) A_device, A_offset, lda, (cl_mem) x_device, x_offset, ldb, beta, (cl_mem) y_device, y_offset, ldc, 1, queue, 0, NULL, NULL) ) ) {
-			LOG(ERROR) << "clblasDgemm() failed on GPU "<<gpu->name();
+      LOG(ERROR) << "clblasDgemm() failed on GPU "<<device.name();
 			return false;
 			//clReleaseSubBuffers(sb);
 			//clReleaseBufferMap(bm);
 		}
 		////clFinish(*queue);
-		DLOG(INFO) << "clblasDgemm() succeeded on GPU "<<gpu->name();
+    DLOG(INFO) << "clblasDgemm() succeeded on GPU "<<device.name();
 	}
 
 	/*
@@ -1585,10 +1562,11 @@ template bool clBLASgemm<double>(const clblasTranspose TransA, const clblasTrans
 
 template<typename T>
 bool clBLASgemm(const clblasTranspose TransA, const clblasTranspose TransB, const int m, const int n, const int k, const T alpha, const T* A, const int step_A, const T* x, const int step_x, const T beta, T* y, const int step_y) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
-	queue = gpu->getQueue();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
@@ -1619,20 +1597,20 @@ bool clBLASgemm(const clblasTranspose TransA, const clblasTranspose TransB, cons
 	  //  {
 	if( typeid(T) == typeid(float) ) {
 		if ( ! CL_CHECK( clblasSgemm(clblasRowMajor, TransA, TransB, m, n, k, alpha, (cl_mem) A_logical, step_A, lda, (cl_mem) x_logical, step_x, ldb, beta, (cl_mem) y_logical, step_y, ldc, 1, queue, 0, NULL, NULL) ) ) {
-			LOG(ERROR) << "clblasSgemm() failed on GPU "<<gpu->name();
+      LOG(ERROR) << "clblasSgemm() failed on GPU "<<device.name();
 			return false;
 		}
 		////clFinish(*queue);
-		DLOG(INFO) << "clblasSgemm() succeeded on GPU "<<gpu->name();
+    DLOG(INFO) << "clblasSgemm() succeeded on GPU "<<device.name();
 	}
 
 	if( typeid(T) == typeid(double) ) {
 		if ( ! CL_CHECK( clblasDgemm(clblasRowMajor, TransA, TransB, m, n, k, alpha, (cl_mem) A_logical, step_A, lda, (cl_mem) x_logical, step_x, ldb, beta, (cl_mem) y_logical, step_y, ldc, 1, queue, 0, NULL, NULL) ) ) {
-			LOG(ERROR) << "clblasDgemm() failed on GPU "<<gpu->name();
+      LOG(ERROR) << "clblasDgemm() failed on GPU "<<device.name();
 			return false;
 		}
 		////clFinish(*queue);
-		DLOG(INFO) << "clblasDgemm() succeeded on GPU "<<gpu->name();
+    DLOG(INFO) << "clblasDgemm() succeeded on GPU "<<device.name();
 	}
 	    //});
 
@@ -1647,10 +1625,11 @@ template bool clBLASgemm<double>(const clblasTranspose TransA, const clblasTrans
 
 template<typename T>
 bool clBLASaxpy(const int N, const T alpha, const T* X, const int incr_x, T* Y, const int incr_y) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
-	queue = gpu->getQueue();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
@@ -1670,22 +1649,22 @@ bool clBLASaxpy(const int N, const T alpha, const T* X, const int incr_x, T* Y, 
 	if( typeid(T) == typeid(float) ) {
 
 		if ( ! CL_CHECK( clblasSaxpy(N, alpha, (cl_mem) X_logical, 0, incr_x, (cl_mem) Y_logical, 0, incr_y, 1, queue, 0, NULL, NULL) ) ) {
-			LOG(ERROR) << "clblasSaxpy() failed on GPU "<<gpu->name();
+      LOG(ERROR) << "clblasSaxpy() failed on GPU "<<device.name();
 			clReleaseSubBuffers(sb);
 			clReleaseBufferMap(bm);
 			return false;
 		}
-		DLOG(INFO) << "clblasSaxpy() succeeded on GPU "<<gpu->name();
+    DLOG(INFO) << "clblasSaxpy() succeeded on GPU "<<device.name();
 	}
 
 	if( typeid(T) == typeid(double) ) {
 		if ( ! CL_CHECK( clblasDaxpy(N, alpha, (cl_mem) X_logical, 0, incr_x, (cl_mem) Y_logical, 0, incr_y, 1, queue, 0, NULL, NULL) ) ) {
-			LOG(ERROR) << "clblasDaxpy() failed on GPU "<<gpu->name();
+      LOG(ERROR) << "clblasDaxpy() failed on GPU "<<device.name();
 			clReleaseSubBuffers(sb);
 			clReleaseBufferMap(bm);
 			return false;
 		}
-		DLOG(INFO) << "clblasDaxpy() succeeded on GPU "<<gpu->name();
+    DLOG(INFO) << "clblasDaxpy() succeeded on GPU "<<device.name();
 	}
 
 	clReleaseSubBuffers(sb);
@@ -1701,6 +1680,7 @@ bool clIsVirtualMemory(const void* p) {
 }
 
 bool clMakeLogical(const void* ptr_virtual, const void** ptr_logical) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
 	if ( ! clIsVirtualMemory(ptr_virtual) ) {
 		LOG(WARNING) << "PTR@"<<ptr_virtual<<" is not in virtual memory.";
@@ -1709,7 +1689,7 @@ bool clMakeLogical(const void* ptr_virtual, const void** ptr_logical) {
 	}
 
 	OpenCLMemory clMem;
-	if ( ! gpu->get(ptr_virtual, clMem) ) {
+  if ( ! device.get(ptr_virtual, clMem) ) {
 		LOG(ERROR) << "failed to get OpenCLMemory object associated with VM@" << ptr_virtual;
 		return false;
 	}
@@ -1724,6 +1704,7 @@ bool clMakeLogical(const void* ptr_virtual, const void** ptr_logical) {
 }
 
 bool clMakeLogical2(const void* ptr_virtual, const void** ptr_logical, std::vector<cl_mem>& subBuffers, std::map<const void*, std::pair<void*, size_t> >& bufferMap) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
 	if ( ! clIsVirtualMemory(ptr_virtual) ) {
 		LOG(WARNING) << "PTR@"<<ptr_virtual<<" is not in virtual memory.";
@@ -1732,7 +1713,7 @@ bool clMakeLogical2(const void* ptr_virtual, const void** ptr_logical, std::vect
 	}
 
 	OpenCLMemory clMem;
-	if ( ! gpu->get(ptr_virtual, clMem) ) {
+  if ( ! device.get(ptr_virtual, clMem) ) {
 		LOG(ERROR) << "failed to get OpenCLMemory object associated with VM@" << ptr_virtual;
 		return false;
 	}
@@ -1750,7 +1731,7 @@ bool clMakeLogical2(const void* ptr_virtual, const void** ptr_logical, std::vect
 	  LOG(INFO)<<"offset = "<<offset;
 
 		/* check alignment */
-		cl_uint bytes = gpu->getDeviceMemBaseAddrAlign();
+    cl_uint bytes = device.getDeviceMemBaseAddrAlign();
 		if ( offset % bytes != 0 ) {
 			LOG(WARNING)<<"sub-buffer memory offset ("<<offset<<" Byte) is not aligned with device memory offset ("<<bytes<<" Byte)";
 
@@ -1782,7 +1763,7 @@ bool clMakeLogical2(const void* ptr_virtual, const void** ptr_logical, std::vect
 		cl_buffer_region region = {offset, size - offset};
 		*ptr_logical = (const void*) clCreateSubBuffer((cl_mem) *ptr_logical, CL_MEM_READ_WRITE, CL_BUFFER_CREATE_TYPE_REGION, &region, &err);
 		if ( err != CL_SUCCESS ) {
-			LOG(ERROR) << "failed to create sub-buffer on GPU "<<gpu->name()<<" : "<<what(err);
+      LOG(ERROR) << "failed to create sub-buffer on GPU "<<device.name()<<" : "<<what(err);
 			return false;
 		}
 		DLOG(INFO)<<"create sub-buffer ";
@@ -1794,6 +1775,7 @@ bool clMakeLogical2(const void* ptr_virtual, const void** ptr_logical, std::vect
 
 
 size_t clGetMemoryOffset(const void* ptr_virtual) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
 	if ( ! clIsVirtualMemory(ptr_virtual) ) {
 		LOG(WARNING) << "PTR@"<<ptr_virtual<<" is not in virtual memory.";
@@ -1801,7 +1783,7 @@ size_t clGetMemoryOffset(const void* ptr_virtual) {
 	}
 
 	OpenCLMemory clMem;
-	if ( ! gpu->get(ptr_virtual, clMem) ) {
+  if ( ! device.get(ptr_virtual, clMem) ) {
 		LOG(ERROR) << "failed to get OpenCLMemory object associated with VM@" << ptr_virtual;
 		return -1;
 	}
@@ -1811,6 +1793,7 @@ size_t clGetMemoryOffset(const void* ptr_virtual) {
 }
 
 size_t clGetMemorySize(const void* ptr_virtual) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
 	if ( ! clIsVirtualMemory(ptr_virtual) ) {
 		LOG(WARNING) << "PTR@"<<ptr_virtual<<" is not in virtual memory.";
@@ -1818,7 +1801,7 @@ size_t clGetMemorySize(const void* ptr_virtual) {
 	}
 
 	OpenCLMemory clMem;
-	if ( ! gpu->get(ptr_virtual, clMem) ) {
+  if ( ! device.get(ptr_virtual, clMem) ) {
 		LOG(ERROR) << "failed to get OpenCLMemory object associated with VM@" << ptr_virtual;
 		return -1;
 	}
@@ -1826,6 +1809,7 @@ size_t clGetMemorySize(const void* ptr_virtual) {
 }
 
 void* clGetMemoryBase(const void* ptr_virtual) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
   if ( ! clIsVirtualMemory(ptr_virtual) ) {
     LOG(WARNING) << "PTR@"<<ptr_virtual<<" is not in virtual memory.";
@@ -1833,7 +1817,7 @@ void* clGetMemoryBase(const void* ptr_virtual) {
   }
 
   OpenCLMemory clMem;
-  if ( ! gpu->get(ptr_virtual, clMem) ) {
+  if ( ! device.get(ptr_virtual, clMem) ) {
     LOG(ERROR) << "failed to get OpenCLMemory object associated with VM@" << ptr_virtual;
     return NULL;
   }
@@ -1842,36 +1826,37 @@ void* clGetMemoryBase(const void* ptr_virtual) {
 
 template<typename T>
 bool clsub(const int n, const T* array_GPU_x, const T* array_GPU_y, T* array_GPU_z) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
 	std::string kernel_name = clGetKernelName<T>("clsub");
 
-	queue = gpu->getQueue();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
-	kernel = gpu->getKernel(kernel_name);
+  cl_kernel* kernel = device.getKernel(kernel_name);
 	if ( kernel == NULL ) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, n)
-	CL_SET_ARRAY_KERNEL_ARG(&array_GPU_x)
-	CL_SET_ARRAY_KERNEL_ARG(&array_GPU_y)
-	CL_SET_ARRAY_KERNEL_ARG(&array_GPU_z)
+  CL_SET_TYPE_KERNEL_ARG(int, n, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&array_GPU_x, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&array_GPU_y, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&array_GPU_z, kernel)
 
 	size_t global = CAFFE_GET_GLOBAL_WORKITEMS(n, OPENCL_LOCAL_SIZE);
 	size_t local  = CAFFE_GET_LOCAL_WORKITEMS(n, OPENCL_LOCAL_SIZE);
 
 	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+    LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<device.name()<<" : "<<caffe::OpenCL::what(err);
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<device.name();
 
 	CL_SET_KERNEL_ARG_END
 
@@ -1882,36 +1867,37 @@ template bool clsub<double>(const int n, const double* array_GPU_x, const double
 
 template<typename T>
 bool cladd(const int n, const T* array_GPU_x, const T* array_GPU_y, T* array_GPU_z) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
 	std::string kernel_name = clGetKernelName<T>("cladd");
 
-	queue = gpu->getQueue();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
-	kernel = gpu->getKernel(kernel_name);
+  cl_kernel* kernel = device.getKernel(kernel_name);
 	if ( kernel == NULL ) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, n)
-	CL_SET_ARRAY_KERNEL_ARG(&array_GPU_x)
-	CL_SET_ARRAY_KERNEL_ARG(&array_GPU_y)
-	CL_SET_ARRAY_KERNEL_ARG(&array_GPU_z)
+  CL_SET_TYPE_KERNEL_ARG(int, n, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&array_GPU_x, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&array_GPU_y, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&array_GPU_z, kernel)
 
 	size_t global = CAFFE_GET_GLOBAL_WORKITEMS(n, OPENCL_LOCAL_SIZE);
 	size_t local  = CAFFE_GET_LOCAL_WORKITEMS(n, OPENCL_LOCAL_SIZE);
 
 	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+    LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<device.name()<<" : "<<caffe::OpenCL::what(err);
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<device.name();
 
 	CL_SET_KERNEL_ARG_END
 
@@ -1922,35 +1908,36 @@ template bool cladd<double>(const int n, const double* array_GPU_x, const double
 
 template<typename T>
 bool cladd_scalar(const int N, const T alpha, T* Y) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
 	std::string kernel_name = clGetKernelName<T>("cladd_scalar");
 
-	queue = gpu->getQueue();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
-	kernel = gpu->getKernel(kernel_name);
+  cl_kernel* kernel = device.getKernel(kernel_name);
 	if ( kernel == NULL ) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, N)
-	CL_SET_TYPE_KERNEL_ARG(T, alpha)
-	CL_SET_ARRAY_KERNEL_ARG(&Y)
+  CL_SET_TYPE_KERNEL_ARG(int, N, kernel)
+  CL_SET_TYPE_KERNEL_ARG(T, alpha, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&Y, kernel)
 
 	size_t global = CAFFE_GET_GLOBAL_WORKITEMS(N, OPENCL_LOCAL_SIZE);
 	size_t local  = CAFFE_GET_LOCAL_WORKITEMS(N, OPENCL_LOCAL_SIZE);
 
 	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+    LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<device.name()<<" : "<<caffe::OpenCL::what(err);
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<device.name();
 
 	CL_SET_KERNEL_ARG_END
 
@@ -1961,36 +1948,37 @@ template bool cladd_scalar<double>(const int N, const double alpha, double* Y);
 
 template<typename T>
 bool clpowx(const int n, const T* array_GPU_x, const T alpha, T* array_GPU_z) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
 	std::string kernel_name = clGetKernelName<T>("clpowx");
 
-	queue = gpu->getQueue();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
-	kernel = gpu->getKernel(kernel_name);
+  cl_kernel* kernel = device.getKernel(kernel_name);
 	if ( kernel == NULL ) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, n)
-	CL_SET_ARRAY_KERNEL_ARG(&array_GPU_x)
-	CL_SET_TYPE_KERNEL_ARG(T, alpha)
-	CL_SET_ARRAY_KERNEL_ARG(&array_GPU_z)
+  CL_SET_TYPE_KERNEL_ARG(int, n, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&array_GPU_x, kernel)
+  CL_SET_TYPE_KERNEL_ARG(T, alpha, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&array_GPU_z, kernel)
 
 	size_t global = CAFFE_GET_GLOBAL_WORKITEMS(n, OPENCL_LOCAL_SIZE);
 	size_t local  = CAFFE_GET_LOCAL_WORKITEMS(n, OPENCL_LOCAL_SIZE);
 
 	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+    LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<device.name()<<" : "<<caffe::OpenCL::what(err);
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<device.name();
 
 	CL_SET_KERNEL_ARG_END
 
@@ -2001,35 +1989,36 @@ template bool clpowx<double>(const int n, const double* array_GPU_x, const doubl
 
 template<typename T>
 bool clexp(const int n, const T* array_GPU_x, T* array_GPU_y) {
+  OpenCLDevice& device = OpenCLManager::CurrentPlatform().CurrentDevice();
 
 	std::string kernel_name = clGetKernelName<T>("clexp");
 
-	queue = gpu->getQueue();
+  cl_command_queue* queue = device.getQueue();
 	if ( ! queue ) {
-		LOG(ERROR) << gpu->name() << "> failed to get OpenCL command queue";
+    LOG(ERROR) << device.name() << "> failed to get OpenCL command queue";
 		return false;
 	}
 
-	kernel = gpu->getKernel(kernel_name);
+  cl_kernel* kernel = device.getKernel(kernel_name);
 	if ( kernel == NULL ) {
 		return false;
 	}
 
 	CL_SET_KERNEL_ARG
-	CL_SET_TYPE_KERNEL_ARG(int, n)
-	CL_SET_ARRAY_KERNEL_ARG(&array_GPU_x)
-	CL_SET_ARRAY_KERNEL_ARG(&array_GPU_y)
+  CL_SET_TYPE_KERNEL_ARG(int, n, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&array_GPU_x, kernel)
+  CL_SET_ARRAY_KERNEL_ARG(&array_GPU_y, kernel)
 
 	size_t global = CAFFE_GET_GLOBAL_WORKITEMS(n, OPENCL_LOCAL_SIZE);
 	size_t local  = CAFFE_GET_LOCAL_WORKITEMS(n, OPENCL_LOCAL_SIZE);
 
 	err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
 	if ( err != CL_SUCCESS ) {
-		LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+    LOG(ERROR) << "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<device.name()<<" : "<<caffe::OpenCL::what(err);
 		return false;
 	}
 	//clFinish(*queue);
-	DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+  DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<device.name();
 
 	CL_SET_KERNEL_ARG_END
 

--- a/src/caffe/util/OpenCL/OpenCLSupport.cpp
+++ b/src/caffe/util/OpenCL/OpenCLSupport.cpp
@@ -14,7 +14,7 @@ namespace caffe {
 
 namespace OpenCL {
 
-bool inititialized = false;
+//bool inititialized = false;
 //caffe::OpenCLPlatform* pf;
 //caffe::OpenCLDevice* gpu;
 //cl_context*	context;

--- a/src/caffe/util/benchmark.cpp
+++ b/src/caffe/util/benchmark.cpp
@@ -24,13 +24,15 @@ Timer::~Timer() {
 void Timer::Start() {
 
   if (!running()) {
-    if (Caffe::mode() == Caffe::GPU ) { //&& Caffe::GPU_USE_CUDA ) {
 #ifdef USE_CUDA
+    if (Caffe::mode() == Caffe::GPU ) { //&& Caffe::GPU_USE_CUDA ) {
       CUDA_CHECK(cudaEventRecord(start_gpu_, 0));
-#endif
     } else {
+#endif
       start_cpu_ = boost::posix_time::microsec_clock::local_time();
+#ifdef USE_CUDA
     }
+#endif
     running_ = true;
     has_run_at_least_once_ = true;
   }
@@ -38,14 +40,16 @@ void Timer::Start() {
 
 void Timer::Stop() {
   if (running()) {
-    if (Caffe::mode() == Caffe::GPU ) { //&& Caffe::GPU_USE_CUDA) {
 #if defined(USE_CUDA)
+    if (Caffe::mode() == Caffe::GPU ) { //&& Caffe::GPU_USE_CUDA) {
       CUDA_CHECK(cudaEventRecord(stop_gpu_, 0));
       CUDA_CHECK(cudaEventSynchronize(stop_gpu_));
-#endif
     } else {
+#endif
       stop_cpu_ = boost::posix_time::microsec_clock::local_time();
+#if defined(USE_CUDA)
     }
+#endif
     running_ = false;
   }
 }
@@ -59,16 +63,18 @@ float Timer::MicroSeconds() {
   if (running()) {
     Stop();
   }
-  if (Caffe::mode() == Caffe::GPU ) { //&& Caffe::GPU_USE_CUDA ) {
 #ifdef USE_CUDA
+  if (Caffe::mode() == Caffe::GPU ) { //&& Caffe::GPU_USE_CUDA ) {
     CUDA_CHECK(cudaEventElapsedTime(&elapsed_milliseconds_, start_gpu_,
                                     stop_gpu_));
     // Cuda only measure milliseconds
     elapsed_microseconds_ = elapsed_milliseconds_ * 1000;
-#endif
   } else {
+#endif
     elapsed_microseconds_ = (stop_cpu_ - start_cpu_).total_microseconds();
+#ifdef USE_CUDA
   }
+#endif
   return elapsed_microseconds_;
 }
 
@@ -80,14 +86,17 @@ float Timer::MilliSeconds() {
   if (running()) {
     Stop();
   }
-  if ( Caffe::mode() == Caffe::GPU ) { //&& Caffe::GPU_USE_CUDA ) {
+
 #ifdef USE_CUDA
+  if ( Caffe::mode() == Caffe::GPU ) { //&& Caffe::GPU_USE_CUDA {
     CUDA_CHECK(cudaEventElapsedTime(&elapsed_milliseconds_, start_gpu_,
                                     stop_gpu_));
-#endif
   } else {
+#endif
     elapsed_milliseconds_ = (stop_cpu_ - start_cpu_).total_milliseconds();
+#ifdef USE_CUDA
   }
+#endif
   return elapsed_milliseconds_;
 }
 

--- a/src/caffe/util/benchmark.cpp
+++ b/src/caffe/util/benchmark.cpp
@@ -13,7 +13,7 @@ Timer::Timer()
 }
 
 Timer::~Timer() {
-  if (Caffe::mode() == Caffe::GPU && Caffe::GPU_USE_CUDA ) {
+  if (Caffe::mode() == Caffe::GPU ) { //&& Caffe::GPU_USE_CUDA ) {
 #if defined(USE_CUDA)
     CUDA_CHECK(cudaEventDestroy(start_gpu_));
     CUDA_CHECK(cudaEventDestroy(stop_gpu_));
@@ -24,7 +24,7 @@ Timer::~Timer() {
 void Timer::Start() {
 
   if (!running()) {
-    if (Caffe::mode() == Caffe::GPU && Caffe::GPU_USE_CUDA ) {
+    if (Caffe::mode() == Caffe::GPU ) { //&& Caffe::GPU_USE_CUDA ) {
 #ifdef USE_CUDA
       CUDA_CHECK(cudaEventRecord(start_gpu_, 0));
 #endif
@@ -38,7 +38,7 @@ void Timer::Start() {
 
 void Timer::Stop() {
   if (running()) {
-    if (Caffe::mode() == Caffe::GPU && Caffe::GPU_USE_CUDA) {
+    if (Caffe::mode() == Caffe::GPU ) { //&& Caffe::GPU_USE_CUDA) {
 #if defined(USE_CUDA)
       CUDA_CHECK(cudaEventRecord(stop_gpu_, 0));
       CUDA_CHECK(cudaEventSynchronize(stop_gpu_));
@@ -59,7 +59,7 @@ float Timer::MicroSeconds() {
   if (running()) {
     Stop();
   }
-  if (Caffe::mode() == Caffe::GPU && Caffe::GPU_USE_CUDA ) {
+  if (Caffe::mode() == Caffe::GPU ) { //&& Caffe::GPU_USE_CUDA ) {
 #ifdef USE_CUDA
     CUDA_CHECK(cudaEventElapsedTime(&elapsed_milliseconds_, start_gpu_,
                                     stop_gpu_));
@@ -80,7 +80,7 @@ float Timer::MilliSeconds() {
   if (running()) {
     Stop();
   }
-  if ( Caffe::mode() == Caffe::GPU && Caffe::GPU_USE_CUDA ) {
+  if ( Caffe::mode() == Caffe::GPU ) { //&& Caffe::GPU_USE_CUDA ) {
 #ifdef USE_CUDA
     CUDA_CHECK(cudaEventElapsedTime(&elapsed_milliseconds_, start_gpu_,
                                     stop_gpu_));
@@ -97,7 +97,7 @@ float Timer::Seconds() {
 
 void Timer::Init() {
   if (!initted()) {
-    if (Caffe::mode() == Caffe::GPU && Caffe::GPU_USE_CUDA) {
+    if (Caffe::mode() == Caffe::GPU ) { //&& Caffe::GPU_USE_CUDA) {
 #ifdef USE_CUDA
       CUDA_CHECK(cudaEventCreate(&start_gpu_));
       CUDA_CHECK(cudaEventCreate(&stop_gpu_));
@@ -194,16 +194,16 @@ bool Timer::log(std::string file, record result) {
 #ifdef USE_OPENCL
 	if ( Caffe::mode() == Caffe::CPU ) {
 		result.device = "CPU";
-		if ( caffe::OpenCL::pf->getNumDevices(CL_DEVICE_TYPE_CPU) > 0 ) {
-			if ( caffe::OpenCL::pf->getDevice(CL_DEVICE_TYPE_CPU, 0) != NULL ) {
-				result.device = caffe::OpenCL::pf->getDevice(CL_DEVICE_TYPE_CPU, 0)->name();
+    if ( OpenCLManager::CurrentPlatform().getNumDevices(CL_DEVICE_TYPE_CPU) > 0 ) {
+      if ( OpenCLManager::CurrentPlatform().getDevice(CL_DEVICE_TYPE_CPU, 0) != NULL ) {
+        result.device = OpenCLManager::CurrentPlatform().getDevice(CL_DEVICE_TYPE_CPU, 0)->name();
 			}
 		}
 		result.sdk	  = "C++";
 	}
 	if ( Caffe::mode() == Caffe::GPU ) {
-		result.device = caffe::OpenCL::pf->getDevice(CL_DEVICE_TYPE_GPU, 0)->name();
-		result.sdk = std::string(caffe::OpenCL::pf->version());
+    result.device = OpenCLManager::CurrentPlatform().getDevice(CL_DEVICE_TYPE_GPU, 0)->name();
+    result.sdk = OpenCLManager::CurrentPlatform().version();
 	}
 #endif
 

--- a/src/caffe/util/im2col.cpp
+++ b/src/caffe/util/im2col.cpp
@@ -147,42 +147,46 @@ namespace caffe {
 
       std::string kernel_name = clGetKernelName < T > ("clim2col");
 
-      queue = gpu->getQueue();
+      OpenCLDevice& current_device = OpenCLManager::CurrentPlatform().CurrentDevice();
+      cl_command_queue* queue = current_device.getQueue();
       if (!queue) {
-        LOG(ERROR)<< gpu->name() << "> failed to get OpenCL command queue";
+        LOG(ERROR)<< current_device.name() << "> failed to get OpenCL command queue";
         return false;
       }
 
-      kernel = gpu->getKernel(kernel_name);
+      cl_kernel* kernel = current_device.getKernel(kernel_name);
       if (kernel == NULL) {
         return false;
       }
 
       CL_SET_KERNEL_ARG
-      CL_SET_TYPE_KERNEL_ARG(int, n)
-      CL_SET_ARRAY_KERNEL_ARG (&data_im)
-      CL_SET_TYPE_KERNEL_ARG(int, height)
-      CL_SET_TYPE_KERNEL_ARG(int, width)
-      CL_SET_TYPE_KERNEL_ARG(int, kernel_h)
-      CL_SET_TYPE_KERNEL_ARG(int, kernel_w)
-      CL_SET_TYPE_KERNEL_ARG(int, pad_h)
-      CL_SET_TYPE_KERNEL_ARG(int, pad_w)
-      CL_SET_TYPE_KERNEL_ARG(int, stride_h)
-      CL_SET_TYPE_KERNEL_ARG(int, stride_w)
-      CL_SET_TYPE_KERNEL_ARG(int, height_col)
-      CL_SET_TYPE_KERNEL_ARG(int, width_col)
-      CL_SET_ARRAY_KERNEL_ARG(&data_col)
+      CL_SET_TYPE_KERNEL_ARG(int, n, kernel)
+      CL_SET_ARRAY_KERNEL_ARG (&data_im, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, height, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, width, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, kernel_h, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, kernel_w, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, pad_h, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, pad_w, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, stride_h, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, stride_w, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, height_col, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, width_col, kernel)
+      CL_SET_ARRAY_KERNEL_ARG(&data_col, kernel)
 
       size_t global = CAFFE_GET_GLOBAL_WORKITEMS(n, OPENCL_LOCAL_SIZE);
       size_t local = CAFFE_GET_LOCAL_WORKITEMS(n, OPENCL_LOCAL_SIZE);
 
       err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
       if (err != CL_SUCCESS) {
-        LOG(ERROR)<< "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+        LOG(ERROR)<< "Failed to enqueue kernel '" <<
+                     kernel_name.c_str()<<"' on GPU "<<
+                     current_device.name()<<" : "<<caffe::OpenCL::what(err);
         return false;
       }
       //clFinish (*queue);
-      DLOG(INFO)<< "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+      DLOG(INFO)<< "kernel '"<<kernel_name.c_str() <<
+                   "' executed on GPU "<< current_device.name();
 
       CL_SET_KERNEL_ARG_END
 
@@ -236,44 +240,49 @@ namespace caffe {
 
       std::string kernel_name = clGetKernelName < T > ("clim2col_perf2");
 
-      queue = gpu->getQueue();
+      OpenCLDevice& current_device = OpenCLManager::CurrentPlatform().CurrentDevice();
+      cl_command_queue* queue = current_device.getQueue();
       if (!queue) {
-        LOG(ERROR)<< gpu->name() << "> failed to get OpenCL command queue";
+        LOG(ERROR)<< current_device.name() << "> failed to get OpenCL command queue";
         return false;
       }
 
-      kernel = gpu->getKernel(kernel_name);
+      cl_kernel* kernel = current_device.getKernel(kernel_name);
       if (kernel == NULL) {
         return false;
       }
 
       CL_SET_KERNEL_ARG
-      CL_SET_TYPE_KERNEL_ARG(int, n)
-      CL_SET_ARRAY_KERNEL_ARG (&data_im)
-      CL_SET_TYPE_KERNEL_ARG(int, data_im_step)
-      CL_SET_TYPE_KERNEL_ARG(int, height)
-      CL_SET_TYPE_KERNEL_ARG(int, width)
-      CL_SET_TYPE_KERNEL_ARG(int, kernel_h)
-      CL_SET_TYPE_KERNEL_ARG(int, kernel_w)
-      CL_SET_TYPE_KERNEL_ARG(int, pad_h)
-      CL_SET_TYPE_KERNEL_ARG(int, pad_w)
-      CL_SET_TYPE_KERNEL_ARG(int, stride_h)
-      CL_SET_TYPE_KERNEL_ARG(int, stride_w)
-      CL_SET_TYPE_KERNEL_ARG(int, height_col)
-      CL_SET_TYPE_KERNEL_ARG(int, width_col)
-      CL_SET_ARRAY_KERNEL_ARG(&data_col)
-      CL_SET_TYPE_KERNEL_ARG(int, data_col_step)
+      CL_SET_TYPE_KERNEL_ARG(int, n, kernel)
+      CL_SET_ARRAY_KERNEL_ARG (&data_im, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, data_im_step, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, height, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, width, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, kernel_h, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, kernel_w, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, pad_h, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, pad_w, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, stride_h, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, stride_w, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, height_col, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, width_col, kernel)
+      CL_SET_ARRAY_KERNEL_ARG(&data_col, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, data_col_step, kernel)
 
       size_t global = CAFFE_GET_GLOBAL_WORKITEMS(n, OPENCL_LOCAL_SIZE);
       size_t local = CAFFE_GET_LOCAL_WORKITEMS(n, OPENCL_LOCAL_SIZE);
 
       err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
       if (err != CL_SUCCESS) {
-        LOG(ERROR)<< "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+        LOG(ERROR)<< "Failed to enqueue kernel '"
+                  << kernel_name.c_str()
+                  <<"' on GPU "<< current_device.name() << " : "
+                  << caffe::OpenCL::what(err);
         return false;
       }
       //clFinish (*queue);
-      DLOG(INFO)<< "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+      DLOG(INFO) << "kernel '"<<kernel_name.c_str()<<"' executed on GPU "
+                 << current_device.name();
 
       CL_SET_KERNEL_ARG_END
 
@@ -331,36 +340,37 @@ namespace caffe {
         T* data_col,
         const int top_step) {
 
+      OpenCLDevice& current_device = OpenCLManager::CurrentPlatform().CurrentDevice();
       std::string kernel_name = clGetKernelName < T > ("clim2col_perf");
 
-      queue = gpu->getQueue();
+      cl_command_queue* queue = current_device.getQueue();
       if (!queue) {
-        LOG(ERROR)<< gpu->name() << "> failed to get OpenCL command queue";
+        LOG(ERROR)<< current_device.name() << "> failed to get OpenCL command queue";
         return false;
       }
 
-      kernel = gpu->getKernel(kernel_name);
+      cl_kernel* kernel = current_device.getKernel(kernel_name);
       if (kernel == NULL) {
         return false;
       }
 
       CL_SET_KERNEL_ARG
-      CL_SET_TYPE_KERNEL_ARG(int, num_kernels)
-      CL_SET_ARRAY_KERNEL_ARG (&data_im)
-      CL_SET_TYPE_KERNEL_ARG(int, bottom_step)
-      CL_SET_TYPE_KERNEL_ARG(int, num_channels)
-      CL_SET_TYPE_KERNEL_ARG(int, height)
-      CL_SET_TYPE_KERNEL_ARG(int, width)
-      CL_SET_TYPE_KERNEL_ARG(int, kernel_h)
-      CL_SET_TYPE_KERNEL_ARG(int, kernel_w)
-      CL_SET_TYPE_KERNEL_ARG(int, pad_h)
-      CL_SET_TYPE_KERNEL_ARG(int, pad_w)
-      CL_SET_TYPE_KERNEL_ARG(int, stride_h)
-      CL_SET_TYPE_KERNEL_ARG(int, stride_w)
-      CL_SET_TYPE_KERNEL_ARG(int, height_col)
-      CL_SET_TYPE_KERNEL_ARG(int, width_col)
-      CL_SET_ARRAY_KERNEL_ARG(&data_col)
-      CL_SET_TYPE_KERNEL_ARG(int, top_step)
+      CL_SET_TYPE_KERNEL_ARG(int, num_kernels, kernel)
+      CL_SET_ARRAY_KERNEL_ARG (&data_im, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, bottom_step, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, num_channels, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, height, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, width, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, kernel_h, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, kernel_w, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, pad_h, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, pad_w, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, stride_h, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, stride_w, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, height_col, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, width_col, kernel)
+      CL_SET_ARRAY_KERNEL_ARG(&data_col, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, top_step, kernel)
 
       int dim = 1;
       size_t *global;
@@ -390,11 +400,14 @@ namespace caffe {
 
       err = clEnqueueNDRangeKernel(*queue, *kernel, dim, NULL, global, local, 0, NULL, NULL);
       if (err != CL_SUCCESS) {
-        LOG(ERROR)<< "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+        LOG(ERROR)<< "Failed to enqueue kernel '"<< kernel_name.c_str()
+                  << "' on GPU " << current_device.name()
+                  << " : " << caffe::OpenCL::what(err);
         return false;
       }
       //clFinish (*queue);
-      DLOG(INFO)<< "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+      DLOG(INFO) << "kernel '" << kernel_name
+                << "' executed on GPU " << current_device.name();
 
       CL_SET_KERNEL_ARG_END
 
@@ -453,45 +466,50 @@ namespace caffe {
         const int width_col,
         T* data_im) {
 
+      OpenCLDevice& current_device = OpenCLManager::CurrentPlatform().CurrentDevice();
       std::string kernel_name = clGetKernelName < T > ("clcol2im");
 
-      queue = gpu->getQueue();
+      cl_command_queue* queue = current_device.getQueue();
       if (!queue) {
-        LOG(ERROR)<< gpu->name() << "> failed to get OpenCL command queue";
+        LOG(ERROR)<< current_device.name() << "> failed to get OpenCL command queue";
         return false;
       }
 
-      kernel = gpu->getKernel(kernel_name);
+      cl_kernel* kernel = current_device.getKernel(kernel_name);
       if (kernel == NULL) {
         return false;
       }
 
       CL_SET_KERNEL_ARG
-      CL_SET_TYPE_KERNEL_ARG(int, n)
-      CL_SET_ARRAY_KERNEL_ARG (&data_col)
-      CL_SET_TYPE_KERNEL_ARG(int, height)
-      CL_SET_TYPE_KERNEL_ARG(int, width)
-      CL_SET_TYPE_KERNEL_ARG(int, channels)
-      CL_SET_TYPE_KERNEL_ARG(int, patch_h)
-      CL_SET_TYPE_KERNEL_ARG(int, patch_w)
-      CL_SET_TYPE_KERNEL_ARG(int, pad_h)
-      CL_SET_TYPE_KERNEL_ARG(int, pad_w)
-      CL_SET_TYPE_KERNEL_ARG(int, stride_h)
-      CL_SET_TYPE_KERNEL_ARG(int, stride_w)
-      CL_SET_TYPE_KERNEL_ARG(int, height_col)
-      CL_SET_TYPE_KERNEL_ARG(int, width_col)
-      CL_SET_ARRAY_KERNEL_ARG(&data_im)
+      CL_SET_TYPE_KERNEL_ARG(int, n, kernel)
+      CL_SET_ARRAY_KERNEL_ARG (&data_col, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, height, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, width, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, channels, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, patch_h, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, patch_w, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, pad_h, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, pad_w, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, stride_h, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, stride_w, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, height_col, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, width_col, kernel)
+      CL_SET_ARRAY_KERNEL_ARG(&data_im, kernel)
 
       size_t global = CAFFE_GET_GLOBAL_WORKITEMS(n, OPENCL_LOCAL_SIZE);
       size_t local = CAFFE_GET_LOCAL_WORKITEMS(n, OPENCL_LOCAL_SIZE);
 
-      err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
+      err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL,
+                                   &global, &local, 0, NULL, NULL);
       if (err != CL_SUCCESS) {
-        LOG(ERROR)<< "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+        LOG(ERROR)<< "Failed to enqueue kernel '" << kernel_name
+                  <<"' on GPU "<< current_device.name()
+                 <<" : "<<caffe::OpenCL::what(err);
         return false;
       }
       //clFinish (*queue);
-      DLOG(INFO)<< "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+      DLOG(INFO)<< "kernel '"<<kernel_name.c_str()
+                <<"' executed on GPU " << current_device.name();
 
       CL_SET_KERNEL_ARG_END
 
@@ -547,47 +565,51 @@ namespace caffe {
         T* data_im,
         const int data_im_step) {
 
+      OpenCLDevice& current_device = OpenCLManager::CurrentPlatform().CurrentDevice();
       std::string kernel_name = clGetKernelName < T > ("clcol2im_perf2");
 
-      queue = gpu->getQueue();
+      cl_command_queue* queue = current_device.getQueue();
       if (!queue) {
-        LOG(ERROR)<< gpu->name() << "> failed to get OpenCL command queue";
+        LOG(ERROR)<< current_device.name() << "> failed to get OpenCL command queue";
         return false;
       }
 
-      kernel = gpu->getKernel(kernel_name);
+      cl_kernel* kernel = current_device.getKernel(kernel_name);
       if (kernel == NULL) {
         return false;
       }
 
       CL_SET_KERNEL_ARG
-      CL_SET_TYPE_KERNEL_ARG(int, n)
-      CL_SET_ARRAY_KERNEL_ARG (&data_col)
-      CL_SET_TYPE_KERNEL_ARG(int, data_col_step)
-      CL_SET_TYPE_KERNEL_ARG(int, height)
-      CL_SET_TYPE_KERNEL_ARG(int, width)
-      CL_SET_TYPE_KERNEL_ARG(int, channels)
-      CL_SET_TYPE_KERNEL_ARG(int, patch_h)
-      CL_SET_TYPE_KERNEL_ARG(int, patch_w)
-      CL_SET_TYPE_KERNEL_ARG(int, pad_h)
-      CL_SET_TYPE_KERNEL_ARG(int, pad_w)
-      CL_SET_TYPE_KERNEL_ARG(int, stride_h)
-      CL_SET_TYPE_KERNEL_ARG(int, stride_w)
-      CL_SET_TYPE_KERNEL_ARG(int, height_col)
-      CL_SET_TYPE_KERNEL_ARG(int, width_col)
-      CL_SET_ARRAY_KERNEL_ARG(&data_im)
-      CL_SET_TYPE_KERNEL_ARG(int, data_im_step)
+      CL_SET_TYPE_KERNEL_ARG(int, n, kernel)
+      CL_SET_ARRAY_KERNEL_ARG (&data_col, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, data_col_step, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, height, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, width, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, channels, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, patch_h, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, patch_w, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, pad_h, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, pad_w, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, stride_h, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, stride_w, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, height_col, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, width_col, kernel)
+      CL_SET_ARRAY_KERNEL_ARG(&data_im, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, data_im_step, kernel)
 
       size_t global = CAFFE_GET_GLOBAL_WORKITEMS(n, OPENCL_LOCAL_SIZE);
       size_t local = CAFFE_GET_LOCAL_WORKITEMS(n, OPENCL_LOCAL_SIZE);
 
       err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
       if (err != CL_SUCCESS) {
-        LOG(ERROR)<< "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+        LOG(ERROR)<< "Failed to enqueue kernel '"
+                  <<kernel_name.c_str()<<"' on GPU "
+                 << current_device.name()<<" : "<<caffe::OpenCL::what(err);
         return false;
       }
       //clFinish (*queue);
-      DLOG(INFO)<< "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+      DLOG(INFO)<< "kernel '"<< kernel_name
+                <<"' executed on GPU " << current_device.name();
 
       CL_SET_KERNEL_ARG_END
 
@@ -646,49 +668,51 @@ namespace caffe {
         const int width_col,
         T* data_im,
         const int bottom_step) {
-
+      OpenCLDevice& current_device = OpenCLManager::CurrentPlatform().CurrentDevice();
       std::string kernel_name = clGetKernelName < T > ("clcol2im_perf");
-
-      queue = gpu->getQueue();
+      cl_command_queue* queue = current_device.getQueue();
       if (!queue) {
-        LOG(ERROR)<< gpu->name() << "> failed to get OpenCL command queue";
+        LOG(ERROR)<< current_device.name() << "> failed to get OpenCL command queue";
         return false;
       }
 
-      kernel = gpu->getKernel(kernel_name);
+      cl_kernel* kernel = current_device.getKernel(kernel_name);
       if (kernel == NULL) {
         return false;
       }
 
       CL_SET_KERNEL_ARG
-      CL_SET_TYPE_KERNEL_ARG(int, n)
-      CL_SET_ARRAY_KERNEL_ARG (&data_col)
-      CL_SET_TYPE_KERNEL_ARG(int, top_step)
-      CL_SET_TYPE_KERNEL_ARG(int, col_number)
-      CL_SET_TYPE_KERNEL_ARG(int, height)
-      CL_SET_TYPE_KERNEL_ARG(int, width)
-      CL_SET_TYPE_KERNEL_ARG(int, channels)
-      CL_SET_TYPE_KERNEL_ARG(int, patch_h)
-      CL_SET_TYPE_KERNEL_ARG(int, patch_w)
-      CL_SET_TYPE_KERNEL_ARG(int, pad_h)
-      CL_SET_TYPE_KERNEL_ARG(int, pad_w)
-      CL_SET_TYPE_KERNEL_ARG(int, stride_h)
-      CL_SET_TYPE_KERNEL_ARG(int, stride_w)
-      CL_SET_TYPE_KERNEL_ARG(int, height_col)
-      CL_SET_TYPE_KERNEL_ARG(int, width_col)
-      CL_SET_ARRAY_KERNEL_ARG(&data_im)
-      CL_SET_TYPE_KERNEL_ARG(int, bottom_step)
+      CL_SET_TYPE_KERNEL_ARG(int, n, kernel)
+      CL_SET_ARRAY_KERNEL_ARG (&data_col, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, top_step, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, col_number, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, height, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, width, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, channels, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, patch_h, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, patch_w, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, pad_h, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, pad_w, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, stride_h, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, stride_w, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, height_col, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, width_col, kernel)
+      CL_SET_ARRAY_KERNEL_ARG(&data_im, kernel)
+      CL_SET_TYPE_KERNEL_ARG(int, bottom_step, kernel)
 
       size_t global = CAFFE_GET_GLOBAL_WORKITEMS(n, OPENCL_LOCAL_SIZE);
       size_t local = CAFFE_GET_LOCAL_WORKITEMS(n, OPENCL_LOCAL_SIZE);
 
       err = clEnqueueNDRangeKernel(*queue, *kernel, 1, NULL, &global, &local, 0, NULL, NULL);
       if (err != CL_SUCCESS) {
-        LOG(ERROR)<< "Failed to enqueue kernel '"<<kernel_name.c_str()<<"' on GPU "<<gpu->name()<<" : "<<caffe::OpenCL::what(err);
+        LOG(ERROR)<< "Failed to enqueue kernel '"
+                  <<kernel_name.c_str()<<"' on GPU "
+                 << current_device.name()<<" : "<< caffe::OpenCL::what(err);
         return false;
       }
       //clFinish (*queue);
-      DLOG(INFO)<< "kernel '"<<kernel_name.c_str()<<"' executed on GPU "<<gpu->name();
+      DLOG(INFO)<< "kernel '" << kernel_name.c_str()
+                << "' executed on GPU "<< current_device.name();
 
       CL_SET_KERNEL_ARG_END
 


### PR DESCRIPTION
Work in progress. Posting this in case anyone wants to peruse and comment.

1) These changes eliminate the global variables:

``` c++
bool inititialized = false;
caffe::OpenCLPlatform* pf;
caffe::OpenCLDevice* gpu;
cl_context* context;
cl_command_queue* queue;
cl_kernel* kernel;
```

There's a singleton instance of OpenCLManager exposing public static methods and retaining state of current platform and such.
2) Started changing the cl types cl_context, cl_platform_id and cetera over to cl::Context, cl::Platform. Haven't done them all yet, because am considering trying to switch over to boost::compute::\* instead of cl::\* from cl.hpp, in light of [discussion](https://github.com/BVLC/caffe/pull/2195).  This seems promising especially for the code enqueueing kernels, because there is a lot of duplicated boilerplate in the current code to set arguments, enqueue, and check for failure. 

Probably the majority of the lines of code that have changed in the PR are lines where we set kernel arguments, which have the kernel added to the macro parameter list so as to avoid needing the global kernel variable.
3) Hooked up the gpu id flag in caffe and test.testbin so the device (opencl device so it can be CPU or GPU) can be chosen, instead of always only choosing the first GPU device. This was needed so I could choose to run the tests on the Tahiti or Hawaii device.
4) I started opportunistically fixing lint-enforced style (e.g. 80 column limit) as I went, but realized that those changes obscure the real changes I was trying to make, so stopped doing that. But there's some of that in there. Sorry.
5) We were creating a separate context for each device, and one in the platform. This seems unnecessary to me, and in fact if buffers are ever to be shared across devices we want one context for all the sharing devices. So instead I let the platform create a single context, and provide that context to all the devices.
6) I changed some log(ERROR) to log(FATAL) because I don't think we want to keep executing if, for example, we don't find any CL platforms. Probably need a lot more to be so.
7) I think the cl_program leaks at the moment; I was going to replace with cl::Program which cleans up when it is deleted but forgot to circle back to that. 
8) Beware new bugs I probably inserted, with this many changes. But, at least the tests are passing.

Should I carry on, or am I going in a bad direction?
