### PR TITLE
Set device id

### DIFF
--- a/src/caffe/util/OpenCL/OpenCLManager.cpp
+++ b/src/caffe/util/OpenCL/OpenCLManager.cpp
@@ -69,9 +69,7 @@ bool OpenCLManager::Init() {
     LOG(FATAL) << "No GPU devices available at platform " << pf.name();
     return false;
   }
-  //pf.SetCurrentDevice(instance_.device_id_);
-  //FIXME:
-  pf.SetCurrentDevice(1);
+  pf.SetCurrentDevice(instance_.device_id_);
   OpenCLDevice& device = pf.CurrentDevice();
   if (!device.createQueue()) {
     LOG(FATAL) << "failed to create OpenCL command queue for device "


### PR DESCRIPTION
Robert,
Perhaps you hard-wired the device id to 1 for the case of the running the tests, where it would otherwise default it to 0, which is the CPU as the device. If that's the case, one can specify the device id when running the tests, as in this case:

`relative/path/to/build/directory/test/test.testbin-d 1`

where `1` is the id of the opencl device that the gpu tests will be run on. Caffe commands allow the gpu id to be specified explicitly, as in the solver.prototxt or using the -gpu command-line flag. If that suffices you might merge this PR.  In my case I need to be able to specify the device id to select between two different gpus (7950 and a hawaii device).

I notice after pulling your latest master branch that some of the FloatGPU tests are failing (whereas the corresponding CPU and DoubleGPU tests are still passing). In particular [these](https://gist.github.com/jyegerlehner/116aafd0bf9ccf49de2b). If I go back to the branch of the PR I submitted they are passing. Haven't tracked it down yet. Are you seeing that behavior?

Any chance you could enable issues for your fork repo? And pull in the latest BVLC master? I find it merges without conflicts as of last time I tried.

I've been busy elsewhere but am back to the point where I can spend some time on this. Thought I might look into modifying the im2col, col2im kernels to pass in the offset so as to avoid the createSubBuffer overhead. But would like to avoid duplicating effort if you have made progress towards speeding up the convolutions.
Thanks,
Jim
